### PR TITLE
ci: add GitHub Actions workflow for PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+# Usage:
+# git tag v0.x.x  # Must match version in pyproject.toml
+# git push --tags
+
+name: Publish Python Package to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `publish.yml` workflow triggered on GitHub release
- Use PyPI trusted publisher (OIDC) for secure, tokenless publishing
- Build with `python-build`, publish with `pypa/gh-action-pypi-publish`

## Prerequisites
Before merging, ensure the trusted publisher is configured on PyPI:
1. Go to PyPI project settings → Publishing
2. Add a new trusted publisher with:
   - Owner: `zilliztech`
   - Repository: `vector-graph-rag`
   - Workflow: `publish.yml`
   - Environment: `pypi`

## Test plan
- [ ] Verify PyPI trusted publisher is configured
- [ ] Create a GitHub release to trigger the workflow
- [ ] Check package appears on https://pypi.org/p/vector-graph-rag

🤖 Generated with [Claude Code](https://claude.ai/claude-code)