### PR TITLE
fix: add setuptools<71 constraint for milvus-lite compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vector-graph-rag"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Graph RAG implementation using pure vector search with Milvus"
 readme = "README.md"
 license = { text = "MIT" }
@@ -36,6 +36,7 @@ dependencies = [
     "torch>=2.0.0",
     "langchain-core>=0.3.0",
     "python-multipart>=0.0.22",
+    "setuptools<71",  # Required for pkg_resources used by milvus-lite
 ]
 
 [project.optional-dependencies]
@@ -54,6 +55,7 @@ all = [
 loaders = [
     "markitdown[docx,pdf]>=0.1.4",
     "trafilatura>=2.0.0",
+    "lxml_html_clean",  # Required by trafilatura/justext
 ]
 
 # ==================== PyTorch Index Configuration ====================


### PR DESCRIPTION
## Summary
- Add `setuptools<71` constraint to fix `pkg_resources` import error with milvus-lite
- Add `lxml_html_clean` to loaders dependencies (required by trafilatura/justext)
- Bump version to 0.1.1

## Problem
`setuptools>=71` removed the `pkg_resources` module, which causes:
```
ModuleNotFoundError: No module named 'pkg_resources'
```
when initializing milvus-lite for local database connections.

## Test plan
- [x] Tested with fresh Python 3.10 venv
- [x] Verified URL fetch and full RAG pipeline works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)