### PR TITLE
fix: replace eval() with json.loads(), add embedding retry, use dynamic version

### DIFF
--- a/src/vector_graph_rag/api/app.py
+++ b/src/vector_graph_rag/api/app.py
@@ -20,7 +20,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
-from vector_graph_rag import VectorGraphRAG
+from vector_graph_rag import VectorGraphRAG, __version__
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.storage.milvus import MilvusStore
 from vector_graph_rag.graph.graph import Graph
@@ -32,7 +32,7 @@ from vector_graph_rag.models import Triplet
 class HealthResponse(BaseModel):
     """Health check response."""
     status: str = Field(default="ok", description="Service status")
-    version: str = Field(default="0.1.0", description="API version")
+    version: str = Field(default=__version__, description="API version")
 
 
 class GraphInfo(BaseModel):
@@ -258,7 +258,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     app = FastAPI(
         title="Vector Graph RAG API",
         description="Graph RAG using pure vector search with Milvus",
-        version="0.1.0",
+        version=__version__,
     )
 
     # Add CORS middleware for frontend
@@ -300,7 +300,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     @app.get("/health", response_model=HealthResponse, tags=["System"])
     async def health_check():
         """Check if the service is running."""
-        return HealthResponse(status="ok", version="0.1.0")
+        return HealthResponse(status="ok", version=__version__)
 
     @app.get("/graphs", response_model=ListGraphsResponse, tags=["System"])
     async def list_graphs():

--- a/src/vector_graph_rag/llm/extractor.py
+++ b/src/vector_graph_rag/llm/extractor.py
@@ -304,10 +304,10 @@ class EntityExtractor:
                 query = row.get(query_col, '')
                 triples_str = row.get('triples', '{}')
                 try:
-                    triples_data = eval(triples_str) if isinstance(triples_str, str) else triples_str
+                    triples_data = json.loads(triples_str) if isinstance(triples_str, str) else triples_str
                     if isinstance(triples_data, dict) and 'named_entities' in triples_data:
                         self.ner_tsv_cache[query] = triples_data['named_entities']
-                except:
+                except (json.JSONDecodeError, KeyError, TypeError):
                     pass
             print(f"Loaded {len(self.ner_tsv_cache)} NER entries from {cache_file}")
         except Exception as e:

--- a/src/vector_graph_rag/storage/embeddings.py
+++ b/src/vector_graph_rag/storage/embeddings.py
@@ -156,10 +156,26 @@ class OpenAIEmbedding:
 
         self.model_name = model_name
         self.client = OpenAI(api_key=api_key, base_url=base_url)
-        self._retry_decorator = retry(
+
+        # Wrap the API call with retry logic
+        @retry(
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=1, min=2, max=10),
         )
+        def _call_api(texts):
+            return self.client.embeddings.create(model=self.model_name, input=texts)
+
+        self._call_api = _call_api
+
+        # Detect embedding dimension lazily
+        self._dimension: Optional[int] = None
+
+    def _get_dimension(self) -> int:
+        """Get embedding dimension by making a test call."""
+        if self._dimension is None:
+            response = self._call_api(["test"])
+            self._dimension = len(response.data[0].embedding)
+        return self._dimension
 
     def encode(
         self,
@@ -182,9 +198,9 @@ class OpenAIEmbedding:
         valid_texts = [texts[i] for i in valid_indices]
 
         if not valid_texts:
-            return np.zeros((len(texts), 1536))
+            return np.zeros((len(texts), self._get_dimension()))
 
-        response = self.client.embeddings.create(model=self.model_name, input=valid_texts)
+        response = self._call_api(valid_texts)
         sorted_data = sorted(response.data, key=lambda x: x.index)
         valid_embeddings = np.array([item.embedding for item in sorted_data])
 


### PR DESCRIPTION
## Summary

- Replace `eval()` with `json.loads()` in NER cache loading to eliminate code injection risk, and narrow bare `except:` to specific exception types
- Apply retry decorator to OpenAI embedding API calls (was created but never used) and fix hardcoded fallback dimension (1536 → dynamic detection)
- Use `__version__` for API version instead of hardcoded `"0.1.0"`

## Test plan

- [x] Verified `json.loads()` correctly parses all existing NER cache TSV files (20/20 success)
- [x] All 66 existing tests pass (1 pre-existing failure in `test_query_basic` unrelated to this change)
- [x] Import verification for all modified modules