### PR TITLE
style: apply ruff lint fixes and code formatting

### DIFF
--- a/src/vector_graph_rag/__init__.py
+++ b/src/vector_graph_rag/__init__.py
@@ -6,17 +6,17 @@ using only vector similarity search, without requiring a separate graph database
 """
 
 from vector_graph_rag.config import Settings
-from vector_graph_rag.models import Document, Triplet, Entity, Relation, Passage
+from vector_graph_rag.graph.builder import GraphBuilder
+from vector_graph_rag.graph.graph import Graph
+from vector_graph_rag.graph.knowledge_graph import SubGraph
+from vector_graph_rag.graph.retriever import GraphRetriever
+from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 from vector_graph_rag.llm.extractor import TripletExtractor
+from vector_graph_rag.llm.reranker import LLMReranker
+from vector_graph_rag.models import Document, Entity, Passage, Relation, Triplet
+from vector_graph_rag.rag import VectorGraphRAG, create_rag
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
-from vector_graph_rag.graph.builder import GraphBuilder
-from vector_graph_rag.graph.retriever import GraphRetriever
-from vector_graph_rag.graph.knowledge_graph import SubGraph
-from vector_graph_rag.graph.graph import Graph
-from vector_graph_rag.llm.reranker import LLMReranker
-from vector_graph_rag.rag import VectorGraphRAG, create_rag
-from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 
 __version__ = "0.1.3"
 

--- a/src/vector_graph_rag/api/app.py
+++ b/src/vector_graph_rag/api/app.py
@@ -9,34 +9,35 @@ Provides RESTful API endpoints for:
 - Graph exploration (stats, neighbors)
 """
 
-import os
-import tempfile
 import shutil
+import tempfile
 from pathlib import Path
-from typing import List, Optional, Dict, Any
-from fastapi import FastAPI, HTTPException, Query, File, UploadFile, Form
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 from vector_graph_rag import VectorGraphRAG, __version__
 from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.storage.milvus import MilvusStore
 from vector_graph_rag.graph.graph import Graph
-from vector_graph_rag.models import Triplet
-
+from vector_graph_rag.storage.milvus import MilvusStore
 
 # ==================== Request/Response Schemas ====================
 
+
 class HealthResponse(BaseModel):
     """Health check response."""
+
     status: str = Field(default="ok", description="Service status")
     version: str = Field(default=__version__, description="API version")
 
 
 class GraphInfo(BaseModel):
     """Information about a graph."""
+
     name: str = Field(..., description="Graph name (collection prefix)")
     entity_collection: str = Field(..., description="Entity collection name")
     relation_collection: str = Field(..., description="Relation collection name")
@@ -46,11 +47,13 @@ class GraphInfo(BaseModel):
 
 class ListGraphsResponse(BaseModel):
     """Response for listing graphs."""
+
     graphs: List[GraphInfo] = Field(default_factory=list, description="Available graphs")
 
 
 class TripletInput(BaseModel):
     """Input for a triplet."""
+
     subject: str = Field(..., description="Subject entity")
     predicate: str = Field(..., description="Predicate/relationship")
     object: str = Field(..., description="Object entity")
@@ -58,17 +61,20 @@ class TripletInput(BaseModel):
 
 class AddDocumentsRequest(BaseModel):
     """Request to add documents."""
+
     documents: List[str] = Field(..., description="List of document texts")
     ids: Optional[List[str]] = Field(default=None, description="Optional list of document IDs")
-    extract_triplets: bool = Field(default=True, description="Whether to extract triplets using LLM")
+    extract_triplets: bool = Field(
+        default=True, description="Whether to extract triplets using LLM"
+    )
     triplets: Optional[List[List[TripletInput]]] = Field(
-        default=None,
-        description="Optional pre-extracted triplets for each document"
+        default=None, description="Optional pre-extracted triplets for each document"
     )
 
 
 class AddDocumentsResponse(BaseModel):
     """Response after adding documents."""
+
     num_documents: int = Field(..., description="Number of documents added")
     num_entities: int = Field(..., description="Number of entities created")
     num_relations: int = Field(..., description="Number of relations created")
@@ -77,10 +83,11 @@ class AddDocumentsResponse(BaseModel):
 
 class ImportRequest(BaseModel):
     """Request to import documents from various sources."""
+
     sources: List[str] = Field(
         ...,
         description="List of file paths or URLs to import",
-        examples=["/path/to/doc.pdf", "https://example.com/article"]
+        examples=["/path/to/doc.pdf", "https://example.com/article"],
     )
     chunk_documents: bool = Field(True, description="Whether to chunk large documents")
     chunk_size: int = Field(1000, description="Max characters per chunk")
@@ -91,6 +98,7 @@ class ImportRequest(BaseModel):
 
 class ImportResponse(BaseModel):
     """Response from document import."""
+
     success: bool
     num_sources: int = Field(..., description="Number of input sources")
     num_documents: int = Field(..., description="Number of documents after conversion")
@@ -102,15 +110,19 @@ class ImportResponse(BaseModel):
 
 class QueryRequest(BaseModel):
     """Request to query the knowledge base."""
+
     question: str = Field(..., description="Question to answer")
     use_reranking: bool = Field(default=True, description="Whether to use LLM reranking")
     entity_top_k: Optional[int] = Field(default=None, description="Number of entities to retrieve")
-    relation_top_k: Optional[int] = Field(default=None, description="Number of relations to retrieve")
+    relation_top_k: Optional[int] = Field(
+        default=None, description="Number of relations to retrieve"
+    )
     expansion_degree: Optional[int] = Field(default=None, description="Subgraph expansion degree")
 
 
 class EntitySchema(BaseModel):
     """Schema for an entity in the subgraph."""
+
     id: str = Field(..., description="Entity ID")
     name: str = Field(..., description="Entity name")
     relation_ids: List[str] = Field(default_factory=list, description="Connected relation IDs")
@@ -119,61 +131,84 @@ class EntitySchema(BaseModel):
 
 class RelationSchema(BaseModel):
     """Schema for a relation in the subgraph."""
+
     id: str = Field(..., description="Relation ID")
     text: str = Field(..., description="Full relation text")
     subject: str = Field(..., description="Subject entity name")
     predicate: str = Field(..., description="Predicate/relationship")
     object: str = Field(..., description="Object entity name")
-    entity_ids: List[str] = Field(default_factory=list, description="Connected entity IDs [subject_id, object_id]")
+    entity_ids: List[str] = Field(
+        default_factory=list, description="Connected entity IDs [subject_id, object_id]"
+    )
     passage_ids: List[str] = Field(default_factory=list, description="Source passage IDs")
 
 
 class PassageSchema(BaseModel):
     """Schema for a passage in the subgraph."""
+
     id: str = Field(..., description="Passage ID")
     text: str = Field(..., description="Passage text")
 
 
 class ExpansionStepSchema(BaseModel):
     """Schema for an expansion step in the history."""
+
     step: int = Field(..., description="Step number")
     operation: str = Field(..., description="Operation type")
     description: Optional[str] = Field(default=None, description="Operation description")
-    added_entity_ids: List[str] = Field(default_factory=list, description="Entity IDs added in this step")
-    added_relation_ids: List[str] = Field(default_factory=list, description="Relation IDs added in this step")
+    added_entity_ids: List[str] = Field(
+        default_factory=list, description="Entity IDs added in this step"
+    )
+    added_relation_ids: List[str] = Field(
+        default_factory=list, description="Relation IDs added in this step"
+    )
     total_entities: int = Field(default=0, description="Total entities after this step")
     total_relations: int = Field(default=0, description="Total relations after this step")
 
 
 class SubGraphSchema(BaseModel):
     """Schema for the expanded subgraph."""
+
     entity_ids: List[str] = Field(default_factory=list, description="All entity IDs in subgraph")
-    relation_ids: List[str] = Field(default_factory=list, description="All relation IDs in subgraph")
+    relation_ids: List[str] = Field(
+        default_factory=list, description="All relation IDs in subgraph"
+    )
     passage_ids: List[str] = Field(default_factory=list, description="All passage IDs in subgraph")
     entities: List[EntitySchema] = Field(default_factory=list, description="Entity details")
     relations: List[RelationSchema] = Field(default_factory=list, description="Relation details")
     passages: List[PassageSchema] = Field(default_factory=list, description="Passage details")
-    expansion_history: List[ExpansionStepSchema] = Field(default_factory=list, description="Expansion history")
+    expansion_history: List[ExpansionStepSchema] = Field(
+        default_factory=list, description="Expansion history"
+    )
 
 
 class RetrievalDetailSchema(BaseModel):
     """Schema for retrieval details."""
+
     entity_ids: List[str] = Field(default_factory=list, description="Retrieved entity IDs")
     entity_texts: List[str] = Field(default_factory=list, description="Retrieved entity names")
     entity_scores: List[float] = Field(default_factory=list, description="Entity similarity scores")
     relation_ids: List[str] = Field(default_factory=list, description="Retrieved relation IDs")
     relation_texts: List[str] = Field(default_factory=list, description="Retrieved relation texts")
-    relation_scores: List[float] = Field(default_factory=list, description="Relation similarity scores")
+    relation_scores: List[float] = Field(
+        default_factory=list, description="Relation similarity scores"
+    )
 
 
 class RerankResultSchema(BaseModel):
     """Schema for rerank results."""
-    selected_relation_ids: List[str] = Field(default_factory=list, description="Selected relation IDs")
-    selected_relation_texts: List[str] = Field(default_factory=list, description="Selected relation texts")
+
+    selected_relation_ids: List[str] = Field(
+        default_factory=list, description="Selected relation IDs"
+    )
+    selected_relation_texts: List[str] = Field(
+        default_factory=list, description="Selected relation texts"
+    )
 
 
 class EvictionResultSchema(BaseModel):
     """Schema for eviction results (when relations exceed threshold)."""
+
     occurred: bool = Field(default=False, description="Whether eviction occurred")
     before_count: int = Field(default=0, description="Number of relations before eviction")
     after_count: int = Field(default=0, description="Number of relations after eviction")
@@ -181,44 +216,62 @@ class EvictionResultSchema(BaseModel):
 
 class QueryResponse(BaseModel):
     """Response for a query."""
+
     question: str = Field(..., description="Original question")
     answer: str = Field(..., description="Generated answer")
-    query_entities: List[str] = Field(default_factory=list, description="Entities extracted from query")
-    subgraph: Optional[SubGraphSchema] = Field(default=None, description="Expanded subgraph for visualization")
+    query_entities: List[str] = Field(
+        default_factory=list, description="Entities extracted from query"
+    )
+    subgraph: Optional[SubGraphSchema] = Field(
+        default=None, description="Expanded subgraph for visualization"
+    )
     retrieved_passages: List[str] = Field(default_factory=list, description="Retrieved passages")
     stats: Dict[str, Any] = Field(default_factory=dict, description="Query statistics")
-    retrieval_detail: Optional[RetrievalDetailSchema] = Field(default=None, description="Initial retrieval details")
-    rerank_result: Optional[RerankResultSchema] = Field(default=None, description="LLM rerank results")
-    eviction_result: Optional[EvictionResultSchema] = Field(default=None, description="Eviction results if relations exceeded threshold")
+    retrieval_detail: Optional[RetrievalDetailSchema] = Field(
+        default=None, description="Initial retrieval details"
+    )
+    rerank_result: Optional[RerankResultSchema] = Field(
+        default=None, description="LLM rerank results"
+    )
+    eviction_result: Optional[EvictionResultSchema] = Field(
+        default=None, description="Eviction results if relations exceeded threshold"
+    )
 
 
 class DocumentResponse(BaseModel):
     """Response for a single document."""
+
     id: str = Field(..., description="Document ID")
     text: str = Field(..., description="Document text")
     entity_ids: List[str] = Field(default_factory=list, description="Entity IDs in this document")
-    relation_ids: List[str] = Field(default_factory=list, description="Relation IDs from this document")
+    relation_ids: List[str] = Field(
+        default_factory=list, description="Relation IDs from this document"
+    )
 
 
 class ListDocumentsResponse(BaseModel):
     """Response for listing documents."""
+
     documents: List[DocumentResponse] = Field(default_factory=list, description="List of documents")
     total: int = Field(..., description="Total number of documents returned")
 
 
 class UpdateDocumentRequest(BaseModel):
     """Request to update a document."""
+
     text: Optional[str] = Field(default=None, description="New document text")
 
 
 class DeleteResponse(BaseModel):
     """Response for delete operations."""
+
     success: bool = Field(..., description="Whether deletion succeeded")
     message: str = Field(default="", description="Additional message")
 
 
 class GraphStatsResponse(BaseModel):
     """Response for graph statistics."""
+
     graph_name: str = Field(..., description="Graph name")
     entity_count: int = Field(default=0, description="Number of entities")
     relation_count: int = Field(default=0, description="Number of relations")
@@ -227,13 +280,17 @@ class GraphStatsResponse(BaseModel):
 
 class NeighborResponse(BaseModel):
     """Response for entity neighbors."""
+
     entity_id: str = Field(..., description="Central entity ID")
     neighbors: List[EntitySchema] = Field(default_factory=list, description="Neighbor entities")
-    relations: List[RelationSchema] = Field(default_factory=list, description="Connecting relations")
+    relations: List[RelationSchema] = Field(
+        default_factory=list, description="Connecting relations"
+    )
 
 
 class SettingsResponse(BaseModel):
     """Response for system settings."""
+
     llm_model: str = Field(..., description="LLM model name")
     embedding_model: str = Field(..., description="Embedding model name")
     embedding_dimension: int = Field(..., description="Embedding dimension")
@@ -244,6 +301,7 @@ class SettingsResponse(BaseModel):
 
 
 # ==================== Application Factory ====================
+
 
 def create_app(settings: Optional[Settings] = None) -> FastAPI:
     """
@@ -314,9 +372,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             milvus_token=app.state.settings.milvus_token,
             milvus_db=app.state.settings.milvus_db,
         )
-        return ListGraphsResponse(
-            graphs=[GraphInfo(**g) for g in graphs]
-        )
+        return ListGraphsResponse(graphs=[GraphInfo(**g) for g in graphs])
 
     @app.get("/settings", response_model=SettingsResponse, tags=["System"])
     async def get_system_settings():
@@ -362,19 +418,15 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             if deleted:
                 return DeleteResponse(
                     success=True,
-                    message=f"Successfully deleted graph '{graph_name}' and all its collections"
+                    message=f"Successfully deleted graph '{graph_name}' and all its collections",
                 )
             else:
                 return DeleteResponse(
-                    success=False,
-                    message=f"Graph '{graph_name}' not found or already deleted"
+                    success=False, message=f"Graph '{graph_name}' not found or already deleted"
                 )
 
         except Exception as e:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to delete graph: {str(e)}"
-            )
+            raise HTTPException(status_code=500, detail=f"Failed to delete graph: {str(e)}")
 
     @app.post("/add_documents", response_model=AddDocumentsResponse, tags=["Documents"])
     async def add_documents(
@@ -395,10 +447,9 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             for i, text in enumerate(request.documents):
                 doc_data = {
                     "passage": text,
-                    "triplets": [
-                        [t.subject, t.predicate, t.object]
-                        for t in request.triplets[i]
-                    ] if i < len(request.triplets) else [],
+                    "triplets": [[t.subject, t.predicate, t.object] for t in request.triplets[i]]
+                    if i < len(request.triplets)
+                    else [],
                 }
                 if request.ids and i < len(request.ids):
                     doc_data["id"] = request.ids[i]
@@ -575,9 +626,9 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         if result.subgraph:
             sg = result.subgraph
             subgraph_schema = SubGraphSchema(
-                entity_ids=list(sg.entity_ids) if hasattr(sg, 'entity_ids') else [],
-                relation_ids=list(sg.relation_ids) if hasattr(sg, 'relation_ids') else [],
-                passage_ids=list(sg.passage_ids) if hasattr(sg, 'passage_ids') else [],
+                entity_ids=list(sg.entity_ids) if hasattr(sg, "entity_ids") else [],
+                relation_ids=list(sg.relation_ids) if hasattr(sg, "relation_ids") else [],
+                passage_ids=list(sg.passage_ids) if hasattr(sg, "passage_ids") else [],
                 entities=[
                     EntitySchema(
                         id=e.id,
@@ -585,7 +636,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                         relation_ids=e.relation_ids,
                         passage_ids=e.passage_ids,
                     )
-                    for e in (sg.entities if hasattr(sg, 'entities') else [])
+                    for e in (sg.entities if hasattr(sg, "entities") else [])
                 ],
                 relations=[
                     RelationSchema(
@@ -597,23 +648,27 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                         entity_ids=r.entity_ids,
                         passage_ids=r.passage_ids,
                     )
-                    for r in (sg.relations if hasattr(sg, 'relations') else [])
+                    for r in (sg.relations if hasattr(sg, "relations") else [])
                 ],
                 passages=[
                     PassageSchema(id=p.id, text=p.text)
-                    for p in (sg.passages if hasattr(sg, 'passages') else [])
+                    for p in (sg.passages if hasattr(sg, "passages") else [])
                 ],
                 expansion_history=[
                     ExpansionStepSchema(
-                        step=h.get('step', i),
-                        operation=h.get('operation', 'unknown'),
-                        description=h.get('description'),
-                        added_entity_ids=h.get('added_entity_ids', h.get('new_entity_ids', [])),
-                        added_relation_ids=h.get('added_relation_ids', h.get('new_relation_ids', [])),
-                        total_entities=h.get('total_entities', 0),
-                        total_relations=h.get('total_relations', 0),
+                        step=h.get("step", i),
+                        operation=h.get("operation", "unknown"),
+                        description=h.get("description"),
+                        added_entity_ids=h.get("added_entity_ids", h.get("new_entity_ids", [])),
+                        added_relation_ids=h.get(
+                            "added_relation_ids", h.get("new_relation_ids", [])
+                        ),
+                        total_entities=h.get("total_entities", 0),
+                        total_relations=h.get("total_relations", 0),
                     )
-                    for i, h in enumerate(sg.expansion_history if hasattr(sg, 'expansion_history') else [])
+                    for i, h in enumerate(
+                        sg.expansion_history if hasattr(sg, "expansion_history") else []
+                    )
                 ],
             )
 
@@ -681,11 +736,11 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             stats = graph.get_stats()
             return GraphStatsResponse(
                 graph_name=graph_name,
-                entity_count=stats.get('entity_count', 0),
-                relation_count=stats.get('relation_count', 0),
-                passage_count=stats.get('passage_count', 0),
+                entity_count=stats.get("entity_count", 0),
+                relation_count=stats.get("relation_count", 0),
+                passage_count=stats.get("passage_count", 0),
             )
-        except Exception as e:
+        except Exception:
             # If stats not available, return zeros
             return GraphStatsResponse(
                 graph_name=graph_name,
@@ -694,7 +749,9 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 passage_count=0,
             )
 
-    @app.get("/graph/{graph_name}/neighbors/{entity_id}", response_model=NeighborResponse, tags=["Graph"])
+    @app.get(
+        "/graph/{graph_name}/neighbors/{entity_id}", response_model=NeighborResponse, tags=["Graph"]
+    )
     async def get_entity_neighbors(
         graph_name: str,
         entity_id: str,
@@ -729,12 +786,14 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             for nid in list(neighbor_ids)[:limit]:
                 neighbor = graph.get_entity(nid)
                 if neighbor:
-                    neighbors.append(EntitySchema(
-                        id=neighbor.id,
-                        name=neighbor.name,
-                        relation_ids=neighbor.relation_ids,
-                        passage_ids=neighbor.passage_ids,
-                    ))
+                    neighbors.append(
+                        EntitySchema(
+                            id=neighbor.id,
+                            name=neighbor.name,
+                            relation_ids=neighbor.relation_ids,
+                            passage_ids=neighbor.passage_ids,
+                        )
+                    )
 
             # Convert relations to schema
             relation_schemas = [
@@ -786,7 +845,9 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     @app.get("/documents", response_model=ListDocumentsResponse, tags=["Documents"])
     async def list_documents(
         graph_name: Optional[str] = Query(default=None, description="Graph name to use"),
-        query: Optional[str] = Query(default=None, description="Optional search query for vector similarity"),
+        query: Optional[str] = Query(
+            default=None, description="Optional search query for vector similarity"
+        ),
         top_k: int = Query(default=10, description="Number of documents to return"),
     ):
         """
@@ -921,6 +982,7 @@ def run_server(host: str = "0.0.0.0", port: int = 8000, reload: bool = False):
         reload: Whether to enable auto-reload.
     """
     import uvicorn
+
     uvicorn.run("vector_graph_rag.api.app:app", host=host, port=port, reload=reload)
 
 

--- a/src/vector_graph_rag/config.py
+++ b/src/vector_graph_rag/config.py
@@ -3,9 +3,10 @@ Configuration management for Vector Graph RAG.
 """
 
 import os
-from typing import Optional, Dict, Any
-from pydantic_settings import BaseSettings
+from typing import Any, Dict, Optional
+
 from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -21,9 +22,7 @@ class Settings(BaseSettings):
         default_factory=lambda: os.getenv("OPENAI_API_KEY"),
         description="OpenAI API key for LLM and embeddings",
     )
-    openai_base_url: Optional[str] = Field(
-        default=None, description="Custom OpenAI API base URL"
-    )
+    openai_base_url: Optional[str] = Field(default=None, description="Custom OpenAI API base URL")
 
     # Model Settings
     llm_model: str = Field(
@@ -80,12 +79,8 @@ class Settings(BaseSettings):
     )
 
     # Retrieval Settings
-    entity_top_k: int = Field(
-        default=20, description="Number of top entities to retrieve"
-    )
-    relation_top_k: int = Field(
-        default=20, description="Number of top relations to retrieve"
-    )
+    entity_top_k: int = Field(default=20, description="Number of top entities to retrieve")
+    relation_top_k: int = Field(default=20, description="Number of top relations to retrieve")
     entity_similarity_threshold: float = Field(
         default=0.9,
         description="Similarity threshold for entity retrieval (keep if score > threshold)",
@@ -101,31 +96,23 @@ class Settings(BaseSettings):
         default=1000,
         description="Maximum number of expanded relations. If exceeded, use eviction strategy to filter by similarity.",
     )
-    final_top_k: int = Field(
-        default=3, description="Number of final passages to return"
-    )
+    final_top_k: int = Field(default=3, description="Number of final passages to return")
 
     # LLM Settings
-    llm_temperature: float = Field(
-        default=0.0, description="Temperature for LLM generation"
-    )
-    llm_max_retries: int = Field(
-        default=3, description="Maximum retries for LLM API calls"
-    )
-    use_llm_cache: bool = Field(
-        default=True, description="Whether to use LLM response caching"
-    )
+    llm_temperature: float = Field(default=0.0, description="Temperature for LLM generation")
+    llm_max_retries: int = Field(default=3, description="Maximum retries for LLM API calls")
+    use_llm_cache: bool = Field(default=True, description="Whether to use LLM response caching")
 
     # Processing Settings
-    batch_size: int = Field(
-        default=32, description="Batch size for embedding and insertion"
-    )
+    batch_size: int = Field(default=32, description="Batch size for embedding and insertion")
 
     # NER Cache Settings
     ner_cache_dir: Optional[str] = Field(
         default_factory=lambda: os.path.join(
             os.path.dirname(os.path.dirname(os.path.dirname(__file__))),  # -> vector-graph-rag/
-            "evaluation", "data", "ner_cache"
+            "evaluation",
+            "data",
+            "ner_cache",
         ),
         description="Directory containing NER cache TSV files (HippoRAG format). "
         "Files should be named {dataset}_queries.named_entity_output.tsv",

--- a/src/vector_graph_rag/graph/__init__.py
+++ b/src/vector_graph_rag/graph/__init__.py
@@ -3,14 +3,14 @@ Graph building and retrieval modules.
 """
 
 from vector_graph_rag.graph.builder import GraphBuilder
-from vector_graph_rag.graph.retriever import GraphRetriever, RetrievalResult
-from vector_graph_rag.graph.knowledge_graph import (
-    SubGraph,
-    GraphEntity,
-    GraphRelation,
-    GraphPassage,
-)
 from vector_graph_rag.graph.graph import Graph
+from vector_graph_rag.graph.knowledge_graph import (
+    GraphEntity,
+    GraphPassage,
+    GraphRelation,
+    SubGraph,
+)
+from vector_graph_rag.graph.retriever import GraphRetriever, RetrievalResult
 
 __all__ = [
     "Graph",

--- a/src/vector_graph_rag/graph/builder.py
+++ b/src/vector_graph_rag/graph/builder.py
@@ -4,17 +4,17 @@ Graph builder for constructing knowledge graph structures from extracted triplet
 
 import uuid
 from collections import defaultdict
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
+from vector_graph_rag.config import Settings, get_settings
+from vector_graph_rag.llm.extractor import processing_phrases
 from vector_graph_rag.models import (
     Document,
     Entity,
+    ExtractionResult,
     Relation,
     Triplet,
-    ExtractionResult,
 )
-from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.llm.extractor import processing_phrases
 
 
 def generate_id() -> str:
@@ -171,10 +171,7 @@ class GraphBuilder:
         self._process_documents(documents)
 
         # Build result
-        entities = [
-            Entity(id=eid, name=self.entities[eid])
-            for eid in self.entity_ids
-        ]
+        entities = [Entity(id=eid, name=self.entities[eid]) for eid in self.entity_ids]
 
         relations = []
         for rid in self.relation_ids:

--- a/src/vector_graph_rag/graph/graph.py
+++ b/src/vector_graph_rag/graph/graph.py
@@ -11,14 +11,14 @@ Design principles:
 - Internal operations automatically handle Entity/Relation creation and linking
 """
 
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.storage.milvus import MilvusStore, generate_id
-from vector_graph_rag.storage.embeddings import EmbeddingModel
-from vector_graph_rag.models import Entity, Relation, Passage, Triplet
 from vector_graph_rag.graph.knowledge_graph import SubGraph
 from vector_graph_rag.llm.extractor import processing_phrases
+from vector_graph_rag.models import Entity, Passage, Relation, Triplet
+from vector_graph_rag.storage.embeddings import EmbeddingModel
+from vector_graph_rag.storage.milvus import MilvusStore, generate_id
 
 
 class Graph:
@@ -128,8 +128,12 @@ class Graph:
                 existing = self._store._get_entities_by_ids([existing_id])
                 if existing:
                     current = existing[0]
-                    new_relation_ids = list(set(current.get("relation_ids", []) + (relation_ids or [])))
-                    new_passage_ids = list(set(current.get("passage_ids", []) + (passage_ids or [])))
+                    new_relation_ids = list(
+                        set(current.get("relation_ids", []) + (relation_ids or []))
+                    )
+                    new_passage_ids = list(
+                        set(current.get("passage_ids", []) + (passage_ids or []))
+                    )
                     self._store._update_entity(
                         existing_id,
                         relation_ids=new_relation_ids,
@@ -326,8 +330,12 @@ class Graph:
         relation_id = id or generate_id()
 
         # Create entities (if not exist) and get their IDs
-        subject_id = self._create_entity(subject, relation_ids=[relation_id], passage_ids=passage_ids)
-        object_id = self._create_entity(object_, relation_ids=[relation_id], passage_ids=passage_ids)
+        subject_id = self._create_entity(
+            subject, relation_ids=[relation_id], passage_ids=passage_ids
+        )
+        object_id = self._create_entity(
+            object_, relation_ids=[relation_id], passage_ids=passage_ids
+        )
 
         # Generate embedding
         embedding = self._embedding_model.embed(relation_text)
@@ -413,8 +421,12 @@ class Graph:
         # Build new text if any triplet field changed
         new_text = None
         if subject or predicate or object_:
-            new_subject = self._normalize_entity_name(subject) if subject else data.get("subject", "")
-            new_predicate = processing_phrases(predicate) if predicate else data.get("predicate", "")
+            new_subject = (
+                self._normalize_entity_name(subject) if subject else data.get("subject", "")
+            )
+            new_predicate = (
+                processing_phrases(predicate) if predicate else data.get("predicate", "")
+            )
             new_object = self._normalize_entity_name(object_) if object_ else data.get("object", "")
             new_text = f"{new_subject} {new_predicate} {new_object}"
 
@@ -453,7 +465,9 @@ class Graph:
             entities = self._store._get_entities_by_ids([eid])
             if entities:
                 e_data = entities[0]
-                new_relation_ids = [rid for rid in e_data.get("relation_ids", []) if rid != relation_id]
+                new_relation_ids = [
+                    rid for rid in e_data.get("relation_ids", []) if rid != relation_id
+                ]
                 self._store._update_entity(eid, relation_ids=new_relation_ids)
 
         # Update related passages (remove this relation from relation_ids)
@@ -461,7 +475,9 @@ class Graph:
             passages = self._store.get_passages_by_ids([pid])
             if passages:
                 p_data = passages[0]
-                new_relation_ids = [rid for rid in p_data.get("relation_ids", []) if rid != relation_id]
+                new_relation_ids = [
+                    rid for rid in p_data.get("relation_ids", []) if rid != relation_id
+                ]
                 self._store.update_passage(pid, relation_ids=new_relation_ids)
 
         # Delete the relation
@@ -528,7 +544,9 @@ class Graph:
                 relation_ids.append(relation_id)
 
                 # Get entity IDs for this triplet
-                subject_id = self._entity_name_to_id.get(self._normalize_entity_name(triplet.subject))
+                subject_id = self._entity_name_to_id.get(
+                    self._normalize_entity_name(triplet.subject)
+                )
                 object_id = self._entity_name_to_id.get(self._normalize_entity_name(triplet.object))
 
                 if subject_id and subject_id not in entity_ids:
@@ -596,12 +614,14 @@ class Graph:
         passages = []
         for r in results:
             data = r["entity"]
-            passages.append(Passage(
-                id=data["id"],
-                text=data["text"],
-                entity_ids=data.get("entity_ids", []),
-                relation_ids=data.get("relation_ids", []),
-            ))
+            passages.append(
+                Passage(
+                    id=data["id"],
+                    text=data["text"],
+                    entity_ids=data.get("entity_ids", []),
+                    relation_ids=data.get("relation_ids", []),
+                )
+            )
 
         return passages
 
@@ -657,7 +677,9 @@ class Graph:
             entities = self._store._get_entities_by_ids([eid])
             if entities:
                 e_data = entities[0]
-                new_passage_ids = [pid for pid in e_data.get("passage_ids", []) if pid != passage_id]
+                new_passage_ids = [
+                    pid for pid in e_data.get("passage_ids", []) if pid != passage_id
+                ]
                 self._store._update_entity(eid, passage_ids=new_passage_ids)
 
         # Update related relations (remove this passage from passage_ids)
@@ -665,7 +687,9 @@ class Graph:
             relations = self._store._get_relations_by_ids([rid])
             if relations:
                 r_data = relations[0]
-                new_passage_ids = [pid for pid in r_data.get("passage_ids", []) if pid != passage_id]
+                new_passage_ids = [
+                    pid for pid in r_data.get("passage_ids", []) if pid != passage_id
+                ]
                 self._store._update_relation(rid, passage_ids=new_passage_ids)
 
         # Delete the passage

--- a/src/vector_graph_rag/graph/knowledge_graph.py
+++ b/src/vector_graph_rag/graph/knowledge_graph.py
@@ -6,8 +6,9 @@ with on-demand data fetching from Milvus storage.
 """
 
 from __future__ import annotations
-from typing import List, Dict, Set, Optional, Any, TYPE_CHECKING
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 if TYPE_CHECKING:
     from vector_graph_rag.storage.milvus import MilvusStore
@@ -401,7 +402,15 @@ class SubGraph:
         results = self._store.client.query(
             collection_name=self._store.relation_collection,
             filter=filter_expr,
-            output_fields=["id", "text", "entity_ids", "passage_ids", "subject", "predicate", "object"],
+            output_fields=[
+                "id",
+                "text",
+                "entity_ids",
+                "passage_ids",
+                "subject",
+                "predicate",
+                "object",
+            ],
         )
 
         for r in results:
@@ -476,23 +485,17 @@ class SubGraph:
     @property
     def entities(self) -> List[GraphEntity]:
         """Get all entity objects in this subgraph."""
-        return [
-            self._entities[eid] for eid in self._entity_ids if eid in self._entities
-        ]
+        return [self._entities[eid] for eid in self._entity_ids if eid in self._entities]
 
     @property
     def relations(self) -> List[GraphRelation]:
         """Get all relation objects in this subgraph."""
-        return [
-            self._relations[rid] for rid in self._relation_ids if rid in self._relations
-        ]
+        return [self._relations[rid] for rid in self._relation_ids if rid in self._relations]
 
     @property
     def passages(self) -> List[GraphPassage]:
         """Get all passage objects in this subgraph."""
-        return [
-            self._passages[pid] for pid in self._passage_ids if pid in self._passages
-        ]
+        return [self._passages[pid] for pid in self._passage_ids if pid in self._passages]
 
     @property
     def entity_names(self) -> List[str]:

--- a/src/vector_graph_rag/graph/retriever.py
+++ b/src/vector_graph_rag/graph/retriever.py
@@ -3,17 +3,17 @@ Graph-based retriever using vector similarity search.
 """
 
 import logging
-from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
-
-logger = logging.getLogger(__name__)
+from typing import List, Optional, Tuple
 
 from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.storage.embeddings import EmbeddingModel
-from vector_graph_rag.storage.milvus import MilvusStore
 from vector_graph_rag.graph.builder import GraphBuilder
 from vector_graph_rag.graph.knowledge_graph import SubGraph
 from vector_graph_rag.llm.extractor import EntityExtractor
+from vector_graph_rag.storage.embeddings import EmbeddingModel
+from vector_graph_rag.storage.milvus import MilvusStore
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -93,9 +93,7 @@ class GraphRetriever:
         self.graph_builder = graph_builder
 
         self.embedding_model = embedding_model or EmbeddingModel(settings=self.settings)
-        self.entity_extractor = entity_extractor or EntityExtractor(
-            settings=self.settings
-        )
+        self.entity_extractor = entity_extractor or EntityExtractor(settings=self.settings)
 
     def _extract_query_entities(self, query: str) -> List[str]:
         """Extract named entities from the query."""
@@ -338,9 +336,7 @@ class GraphRetriever:
         )
 
         # Expand subgraph
-        subgraph = self._expand_subgraph(
-            entity_ids, relation_ids, degree=expansion_degree
-        )
+        subgraph = self._expand_subgraph(entity_ids, relation_ids, degree=expansion_degree)
 
         # Apply eviction strategy if needed
         threshold = relation_number_threshold or self.settings.relation_number_threshold

--- a/src/vector_graph_rag/llm/__init__.py
+++ b/src/vector_graph_rag/llm/__init__.py
@@ -3,8 +3,8 @@ LLM-related modules for extraction, reranking, and caching.
 """
 
 from vector_graph_rag.llm.cache import LLMCache, get_llm_cache, set_llm_cache
-from vector_graph_rag.llm.extractor import TripletExtractor, EntityExtractor
-from vector_graph_rag.llm.reranker import LLMReranker, AnswerGenerator
+from vector_graph_rag.llm.extractor import EntityExtractor, TripletExtractor
+from vector_graph_rag.llm.reranker import AnswerGenerator, LLMReranker
 
 __all__ = [
     "LLMCache",

--- a/src/vector_graph_rag/llm/cache.py
+++ b/src/vector_graph_rag/llm/cache.py
@@ -5,20 +5,19 @@ Caches LLM responses to avoid repeated API calls for the same inputs.
 Uses MD5 hashing of the prompt to create unique cache keys.
 """
 
-import os
-import json
 import hashlib
-from typing import Optional, Dict, Any
+import json
 from pathlib import Path
+from typing import Dict, Optional
 
 
 class LLMCache:
     """
     File-based LLM response cache.
-    
+
     Caches LLM responses using MD5 hash of the prompt as the key.
     Each model has its own cache file.
-    
+
     Example:
         >>> cache = LLMCache()
         >>> cache.get("gpt-4o-mini", "What is 2+2?", temperature=0)
@@ -27,28 +26,28 @@ class LLMCache:
         >>> cache.get("gpt-4o-mini", "What is 2+2?", temperature=0)
         "4"  # Cache hit
     """
-    
+
     def __init__(self, cache_dir: Optional[str] = None):
         """
         Initialize the LLM cache.
-        
+
         Args:
             cache_dir: Directory to store cache files. Defaults to ./llm_cache
         """
         self.cache_dir = Path(cache_dir or "./llm_cache")
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self._cache: Dict[str, Dict[str, str]] = {}
-    
+
     def _get_cache_file(self, model_name: str) -> Path:
         """Get the cache file path for a model."""
         safe_model_name = model_name.replace("/", "-").replace(".", "_")
         return self.cache_dir / f"{safe_model_name}.json"
-    
+
     def _load_cache(self, model_name: str) -> Dict[str, str]:
         """Load cache from file for a model."""
         if model_name in self._cache:
             return self._cache[model_name]
-        
+
         cache_file = self._get_cache_file(model_name)
         if cache_file.exists():
             try:
@@ -58,58 +57,49 @@ class LLMCache:
                 self._cache[model_name] = {}
         else:
             self._cache[model_name] = {}
-        
+
         return self._cache[model_name]
-    
+
     def _save_cache(self, model_name: str) -> None:
         """Save cache to file for a model."""
         cache_file = self._get_cache_file(model_name)
         with open(cache_file, "w", encoding="utf-8") as f:
             json.dump(self._cache.get(model_name, {}), f, indent=2, ensure_ascii=False)
-    
+
     @staticmethod
     def _compute_hash(prompt: str, temperature: float = 0.0, **kwargs) -> str:
         """Compute MD5 hash for a prompt with parameters."""
         cache_key = f"{prompt}\n\ntemperature={temperature}"
         for k, v in sorted(kwargs.items()):
             cache_key += f"\n{k}={v}"
-        
+
         return hashlib.md5(cache_key.encode("utf-8")).hexdigest()
-    
+
     def get(
-        self,
-        model_name: str,
-        prompt: str,
-        temperature: float = 0.0,
-        **kwargs
+        self, model_name: str, prompt: str, temperature: float = 0.0, **kwargs
     ) -> Optional[str]:
         """
         Get cached response for a prompt.
-        
+
         Args:
             model_name: The model name.
             prompt: The prompt text.
             temperature: Temperature setting.
             **kwargs: Additional parameters to include in cache key.
-        
+
         Returns:
             Cached response if exists, None otherwise.
         """
         cache = self._load_cache(model_name)
         hash_key = self._compute_hash(prompt, temperature, **kwargs)
         return cache.get(hash_key)
-    
+
     def set(
-        self,
-        model_name: str,
-        prompt: str,
-        response: str,
-        temperature: float = 0.0,
-        **kwargs
+        self, model_name: str, prompt: str, response: str, temperature: float = 0.0, **kwargs
     ) -> None:
         """
         Cache a response for a prompt.
-        
+
         Args:
             model_name: The model name.
             prompt: The prompt text.
@@ -122,11 +112,11 @@ class LLMCache:
         cache[hash_key] = response
         self._cache[model_name] = cache
         self._save_cache(model_name)
-    
+
     def clear(self, model_name: Optional[str] = None) -> None:
         """
         Clear cache.
-        
+
         Args:
             model_name: If provided, clear only that model's cache.
                        If None, clear all caches.
@@ -141,7 +131,7 @@ class LLMCache:
             for f in self.cache_dir.glob("*.json"):
                 f.unlink()
             self._cache.clear()
-    
+
     def get_stats(self) -> Dict[str, int]:
         """Get cache statistics."""
         stats = {}

--- a/src/vector_graph_rag/llm/extractor.py
+++ b/src/vector_graph_rag/llm/extractor.py
@@ -7,14 +7,15 @@ import logging
 import re
 from typing import List, Optional
 
-logger = logging.getLogger(__name__)
 from openai import OpenAI
 from tenacity import retry, stop_after_attempt, wait_exponential
 from tqdm import tqdm
 
 from vector_graph_rag.config import Settings, get_settings
+from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 from vector_graph_rag.models import Document, Triplet
-from vector_graph_rag.llm.cache import get_llm_cache, LLMCache
+
+logger = logging.getLogger(__name__)
 
 
 def processing_phrases(phrase: str) -> str:
@@ -28,7 +29,7 @@ def processing_phrases(phrase: str) -> str:
     if not phrase:
         return ""
     # Replace all non-alphanumeric characters with space, convert to lowercase, strip
-    return re.sub(r'[^A-Za-z0-9 ]', ' ', phrase.lower()).strip()
+    return re.sub(r"[^A-Za-z0-9 ]", " ", phrase.lower()).strip()
 
 
 # System prompt for triplet extraction
@@ -119,9 +120,7 @@ class TripletExtractor:
         self.settings.validate_settings()
 
         self.model = model or self.settings.llm_model
-        self.temperature = (
-            temperature if temperature is not None else self.settings.llm_temperature
-        )
+        self.temperature = temperature if temperature is not None else self.settings.llm_temperature
 
         self.client = OpenAI(
             api_key=self.settings.openai_api_key,
@@ -222,16 +221,12 @@ class TripletExtractor:
         Returns:
             Documents with extracted triplets stored in metadata["triplets"].
         """
-        iterator = (
-            tqdm(documents, desc="Extracting triplets") if show_progress else documents
-        )
+        iterator = tqdm(documents, desc="Extracting triplets") if show_progress else documents
 
         for doc in iterator:
             triplets = self.extract(doc.page_content)
             # Store triplets as list of [subject, predicate, object] in metadata
-            doc.metadata["triplets"] = [
-                [t.subject, t.predicate, t.object] for t in triplets
-            ]
+            doc.metadata["triplets"] = [[t.subject, t.predicate, t.object] for t in triplets]
 
         return documents
 
@@ -290,8 +285,7 @@ class EntityExtractor:
             if dataset.startswith("ds_"):
                 dataset = dataset[3:]  # Remove "ds_" prefix
             cache_file = os.path.join(
-                self.settings.ner_cache_dir,
-                f"{dataset}_queries.named_entity_output.tsv"
+                self.settings.ner_cache_dir, f"{dataset}_queries.named_entity_output.tsv"
             )
             if os.path.exists(cache_file):
                 self._load_tsv_cache(cache_file)
@@ -299,17 +293,20 @@ class EntityExtractor:
     def _load_tsv_cache(self, cache_file: str) -> None:
         """Load NER results from TSV cache file (HippoRAG format)."""
         import pandas as pd
+
         try:
-            df = pd.read_csv(cache_file, sep='\t')
+            df = pd.read_csv(cache_file, sep="\t")
             # The TSV has columns: query, triples (which contains JSON with named_entities)
-            query_col = 'query' if 'query' in df.columns else 'question'
+            query_col = "query" if "query" in df.columns else "question"
             for _, row in df.iterrows():
-                query = row.get(query_col, '')
-                triples_str = row.get('triples', '{}')
+                query = row.get(query_col, "")
+                triples_str = row.get("triples", "{}")
                 try:
-                    triples_data = json.loads(triples_str) if isinstance(triples_str, str) else triples_str
-                    if isinstance(triples_data, dict) and 'named_entities' in triples_data:
-                        self.ner_tsv_cache[query] = triples_data['named_entities']
+                    triples_data = (
+                        json.loads(triples_str) if isinstance(triples_str, str) else triples_str
+                    )
+                    if isinstance(triples_data, dict) and "named_entities" in triples_data:
+                        self.ner_tsv_cache[query] = triples_data["named_entities"]
                 except (json.JSONDecodeError, KeyError, TypeError):
                     pass
             logger.info("Loaded %d NER entries from %s", len(self.ner_tsv_cache), cache_file)

--- a/src/vector_graph_rag/llm/reranker.py
+++ b/src/vector_graph_rag/llm/reranker.py
@@ -4,12 +4,12 @@ LLM-based reranking for candidate relations.
 
 import json
 from typing import List, Optional, Tuple
+
 from openai import OpenAI
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.llm.cache import get_llm_cache, LLMCache
-
+from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 
 RERANK_EXAMPLE_1_INPUT = """I will provide you with a set of relationship descriptions from a knowledge graph. Select exactly 5 relationships most useful for answering this multi-hop question.
 
@@ -149,9 +149,7 @@ class LLMReranker:
             lines.append(f"[{rid}] {text}")
         return "\n".join(lines)
 
-    def _build_prompt(
-        self, query: str, relation_descriptions: str
-    ) -> str:
+    def _build_prompt(self, query: str, relation_descriptions: str) -> str:
         """Build the full prompt for caching."""
         # Include all 3 few-shot examples in the cache key
         examples = (
@@ -200,7 +198,7 @@ class LLMReranker:
         # gpt-5 series doesn't support 'temperature' and 'stop' parameters
         if not self.model.startswith("gpt-5"):
             api_kwargs["temperature"] = 0
-            api_kwargs["stop"] = ['\n\n']
+            api_kwargs["stop"] = ["\n\n"]
 
         response = self.client.chat.completions.create(**api_kwargs)
         result = response.choices[0].message.content or "{}"
@@ -238,13 +236,8 @@ class LLMReranker:
                         selected_ids.append(rel_id)
                     elif rel_id not in valid_ids:
                         # Try to correct the ID by matching text
-                        corrected_id = _correct_line(
-                            line, relation_texts, relation_ids
-                        )
-                        if (
-                            corrected_id is not None
-                            and corrected_id not in selected_ids
-                        ):
+                        corrected_id = _correct_line(line, relation_texts, relation_ids)
+                        if corrected_id is not None and corrected_id not in selected_ids:
                             selected_ids.append(corrected_id)
 
             return selected_ids
@@ -256,7 +249,6 @@ class LLMReranker:
         query: str,
         relation_ids: List[str],
         relation_texts: List[str],
-        num_select: Optional[int] = None,
     ) -> Tuple[List[str], List[str]]:
         """
         Rerank candidate relations using LLM.
@@ -265,15 +257,12 @@ class LLMReranker:
             query: The query text.
             relation_ids: Candidate relation IDs (string UUIDs).
             relation_texts: Candidate relation texts.
-            num_select: Number of relations to select (default: final_top_k).
 
         Returns:
             Tuple of (selected_relation_ids, selected_relation_texts).
         """
         if not relation_ids:
             return [], []
-
-        num_select = 5
 
         # Format relations
         relation_descriptions = self._format_relations(relation_ids, relation_texts)
@@ -283,9 +272,7 @@ class LLMReranker:
 
         # Parse response
         valid_ids = set(relation_ids)
-        selected_ids = self._parse_response(
-            response, valid_ids, relation_ids, relation_texts
-        )
+        selected_ids = self._parse_response(response, valid_ids, relation_ids, relation_texts)
 
         # No fallback - return whatever LLM selected (same as current project)
 

--- a/src/vector_graph_rag/loaders/__init__.py
+++ b/src/vector_graph_rag/loaders/__init__.py
@@ -7,14 +7,16 @@ Supports importing from:
 
 Focus: Text documents only.
 """
-from typing import List
-from pathlib import Path
-from pydantic import BaseModel
-from langchain_core.documents import Document
 
-from .converter import DocumentConverter, ConversionResult
-from .url_fetcher import URLFetcher
+from pathlib import Path
+from typing import List
+
+from langchain_core.documents import Document
+from pydantic import BaseModel
+
 from .chunker import TextChunker
+from .converter import ConversionResult, DocumentConverter
+from .url_fetcher import URLFetcher
 
 
 class LoaderResult(BaseModel):
@@ -67,9 +69,7 @@ class DocumentImporter:
     ):
         self.converter = DocumentConverter()
         self.url_fetcher = URLFetcher()
-        self.chunker = (
-            TextChunker(chunk_size, chunk_overlap) if chunk_documents else None
-        )
+        self.chunker = TextChunker(chunk_size, chunk_overlap) if chunk_documents else None
 
     def import_sources(
         self,
@@ -112,9 +112,7 @@ class DocumentImporter:
         # Check if supported
         ext = path.suffix.lower()
         if ext not in self.SUPPORTED_EXTENSIONS:
-            return ConversionResult(
-                documents=[], errors=[f"Unsupported file type: {ext}"]
-            )
+            return ConversionResult(documents=[], errors=[f"Unsupported file type: {ext}"])
 
         # Handle different file types
         if ext in (".pdf", ".docx", ".doc"):
@@ -134,13 +132,9 @@ class DocumentImporter:
                 )
                 return ConversionResult(documents=[doc])
             except Exception as e:
-                return ConversionResult(
-                    documents=[], errors=[f"Failed to read {source}: {str(e)}"]
-                )
+                return ConversionResult(documents=[], errors=[f"Failed to read {source}: {str(e)}"])
         else:
-            return ConversionResult(
-                documents=[], errors=[f"Unsupported file type: {ext}"]
-            )
+            return ConversionResult(documents=[], errors=[f"Unsupported file type: {ext}"])
 
     def import_text(self, text: str, source: str = "text_input") -> LoaderResult:
         """
@@ -153,9 +147,7 @@ class DocumentImporter:
         Returns:
             LoaderResult with Document
         """
-        doc = Document(
-            page_content=text, metadata={"source": source, "source_type": "text"}
-        )
+        doc = Document(page_content=text, metadata={"source": source, "source_type": "text"})
 
         documents = [doc]
         if self.chunker:

--- a/src/vector_graph_rag/loaders/chunker.py
+++ b/src/vector_graph_rag/loaders/chunker.py
@@ -2,7 +2,9 @@
 Text chunking for large documents.
 Splits documents into smaller chunks while preserving semantic boundaries.
 """
+
 from typing import List, Optional
+
 from langchain_core.documents import Document
 
 
@@ -74,9 +76,7 @@ class TextChunker:
             return [text[i : i + self.chunk_size] for i in range(0, len(text), step)]
 
         for part in parts:
-            test_chunk = (
-                current_chunk + (chosen_separator if current_chunk else "") + part
-            )
+            test_chunk = current_chunk + (chosen_separator if current_chunk else "") + part
             if len(test_chunk) <= self.chunk_size:
                 current_chunk = test_chunk
             else:

--- a/src/vector_graph_rag/loaders/converter.py
+++ b/src/vector_graph_rag/loaders/converter.py
@@ -2,13 +2,16 @@
 Document converter using Microsoft MarkItDown.
 Supports text documents only: PDF, DOCX
 """
-from typing import List
+
 from pathlib import Path
-from pydantic import BaseModel
+from typing import List
+
 from langchain_core.documents import Document
+from pydantic import BaseModel
 
 try:
     from markitdown import MarkItDown
+
     HAS_MARKITDOWN = True
 except ImportError:
     HAS_MARKITDOWN = False
@@ -54,9 +57,7 @@ class DocumentConverter:
         """
         path = Path(source)
         if not path.exists():
-            return ConversionResult(
-                documents=[], errors=[f"File not found: {source}"]
-            )
+            return ConversionResult(documents=[], errors=[f"File not found: {source}"])
 
         try:
             result = self.md.convert(str(path))
@@ -73,9 +74,7 @@ class DocumentConverter:
             return ConversionResult(documents=[doc])
 
         except Exception as e:
-            return ConversionResult(
-                documents=[], errors=[f"Failed to convert {source}: {str(e)}"]
-            )
+            return ConversionResult(documents=[], errors=[f"Failed to convert {source}: {str(e)}"])
 
     def convert_batch(self, sources: List[str]) -> ConversionResult:
         """Convert multiple files."""

--- a/src/vector_graph_rag/loaders/url_fetcher.py
+++ b/src/vector_graph_rag/loaders/url_fetcher.py
@@ -2,12 +2,15 @@
 URL content fetcher using trafilatura.
 Direct markdown extraction with full structure preservation.
 """
-import trafilatura
+
 import tempfile
-import requests
 from pathlib import Path
-from .converter import ConversionResult, DocumentConverter
+
+import requests
+import trafilatura
 from langchain_core.documents import Document
+
+from .converter import ConversionResult, DocumentConverter
 
 
 class URLFetcher:
@@ -34,25 +37,25 @@ class URLFetcher:
         self.include_images = include_images
         self.converter = DocumentConverter()  # For PDF URLs
         self.headers = {
-            'User-Agent': self.USER_AGENT,
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate',
-            'Connection': 'keep-alive',
+            "User-Agent": self.USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
         }
 
     def _is_pdf_url(self, url: str) -> bool:
         """Check if URL points to a PDF file."""
         # Check by URL extension
-        if url.lower().endswith('.pdf'):
+        if url.lower().endswith(".pdf"):
             return True
 
         # Check by Content-Type header
         try:
             response = requests.head(url, headers=self.headers, timeout=5, allow_redirects=True)
-            content_type = response.headers.get('Content-Type', '').lower()
-            return 'application/pdf' in content_type
-        except:
+            content_type = response.headers.get("Content-Type", "").lower()
+            return "application/pdf" in content_type
+        except Exception:
             return False
 
     def _fetch_pdf_url(self, url: str) -> ConversionResult:
@@ -63,7 +66,7 @@ class URLFetcher:
             response.raise_for_status()
 
             # Create temporary file
-            with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as tmp_file:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
                 tmp_file.write(response.content)
                 tmp_path = tmp_file.name
 
@@ -72,13 +75,13 @@ class URLFetcher:
 
             # Update metadata to reflect URL source
             for doc in result.documents:
-                doc.metadata['source'] = url
-                doc.metadata['source_type'] = 'pdf_url'
+                doc.metadata["source"] = url
+                doc.metadata["source_type"] = "pdf_url"
 
             # Clean up temporary file
             try:
                 Path(tmp_path).unlink()
-            except:
+            except Exception:
                 pass
 
             return result
@@ -104,14 +107,14 @@ class URLFetcher:
                 return self._fetch_pdf_url(url)
 
             # Fetch HTML content for web pages with custom headers
-            response = requests.get(url, headers=self.headers, timeout=self.timeout, allow_redirects=True)
+            response = requests.get(
+                url, headers=self.headers, timeout=self.timeout, allow_redirects=True
+            )
             response.raise_for_status()
             html_content = response.text
 
             if not html_content:
-                return ConversionResult(
-                    documents=[], errors=[f"Failed to fetch URL: {url}"]
-                )
+                return ConversionResult(documents=[], errors=[f"Failed to fetch URL: {url}"])
 
             # Extract content as markdown (best option for text-focused RAG)
             content = trafilatura.extract(
@@ -122,9 +125,7 @@ class URLFetcher:
             )
 
             if not content:
-                return ConversionResult(
-                    documents=[], errors=[f"No content extracted from: {url}"]
-                )
+                return ConversionResult(documents=[], errors=[f"No content extracted from: {url}"])
 
             doc = Document(
                 page_content=content,
@@ -137,9 +138,7 @@ class URLFetcher:
             return ConversionResult(documents=[doc])
 
         except Exception as e:
-            return ConversionResult(
-                documents=[], errors=[f"Failed to fetch {url}: {str(e)}"]
-            )
+            return ConversionResult(documents=[], errors=[f"Failed to fetch {url}: {str(e)}"])
 
     def fetch_batch(self, urls: list[str]) -> ConversionResult:
         """Fetch multiple URLs."""

--- a/src/vector_graph_rag/models.py
+++ b/src/vector_graph_rag/models.py
@@ -2,13 +2,22 @@
 Data models for Vector Graph RAG.
 """
 
-from typing import Optional, List, Any, Dict
-from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Optional
 
 # Re-export Document from langchain_core for unified API
 from langchain_core.documents import Document
+from pydantic import BaseModel, Field
 
-__all__ = ["Document", "Triplet", "Entity", "Relation", "Passage", "QueryResult", "ExtractionResult", "EvictionResult"]
+__all__ = [
+    "Document",
+    "Triplet",
+    "Entity",
+    "Relation",
+    "Passage",
+    "QueryResult",
+    "ExtractionResult",
+    "EvictionResult",
+]
 
 
 class Triplet(BaseModel):
@@ -54,9 +63,7 @@ class Entity(BaseModel):
 
     id: Optional[str] = Field(default=None, description="Entity ID")
     name: str = Field(..., description="Entity name")
-    embedding: Optional[List[float]] = Field(
-        default=None, description="Entity embedding"
-    )
+    embedding: Optional[List[float]] = Field(default=None, description="Entity embedding")
 
     def __hash__(self) -> int:
         return hash(self.name.lower())
@@ -82,12 +89,8 @@ class Relation(BaseModel):
     id: Optional[str] = Field(default=None, description="Relation ID")
     text: str = Field(..., description="Full relation text")
     triplet: Triplet = Field(..., description="Original triplet")
-    source_passage_ids: List[str] = Field(
-        default_factory=list, description="Source passage IDs"
-    )
-    embedding: Optional[List[float]] = Field(
-        default=None, description="Relation embedding"
-    )
+    source_passage_ids: List[str] = Field(default_factory=list, description="Source passage IDs")
+    embedding: Optional[List[float]] = Field(default=None, description="Relation embedding")
 
 
 class Passage(BaseModel):
@@ -106,9 +109,7 @@ class Passage(BaseModel):
     text: str = Field(..., description="Passage text content")
     entity_ids: List[str] = Field(default_factory=list, description="Entity IDs")
     relation_ids: List[str] = Field(default_factory=list, description="Relation IDs")
-    embedding: Optional[List[float]] = Field(
-        default=None, description="Passage embedding"
-    )
+    embedding: Optional[List[float]] = Field(default=None, description="Passage embedding")
 
 
 class RetrievalDetail(BaseModel):
@@ -180,31 +181,17 @@ class QueryResult(BaseModel):
 
     query: str = Field(..., description="Original query")
     answer: str = Field(..., description="Generated answer")
-    query_entities: List[str] = Field(
-        default_factory=list, description="Query entities"
-    )
-    retrieved_passages: List[str] = Field(
-        default_factory=list, description="Retrieved passages"
-    )
-    retrieved_relations: List[str] = Field(
-        default_factory=list, description="Retrieved relations"
-    )
-    expanded_relations: List[str] = Field(
-        default_factory=list, description="Expanded relations"
-    )
-    reranked_relations: List[str] = Field(
-        default_factory=list, description="Reranked relations"
-    )
-    subgraph: Optional[Any] = Field(
-        default=None, description="Expanded subgraph for visualization"
-    )
+    query_entities: List[str] = Field(default_factory=list, description="Query entities")
+    retrieved_passages: List[str] = Field(default_factory=list, description="Retrieved passages")
+    retrieved_relations: List[str] = Field(default_factory=list, description="Retrieved relations")
+    expanded_relations: List[str] = Field(default_factory=list, description="Expanded relations")
+    reranked_relations: List[str] = Field(default_factory=list, description="Reranked relations")
+    subgraph: Optional[Any] = Field(default=None, description="Expanded subgraph for visualization")
     passages: List[str] = Field(default_factory=list, description="Final passages")
     retrieval_detail: Optional[RetrievalDetail] = Field(
         default=None, description="Details of initial retrieval"
     )
-    rerank_result: Optional[RerankResult] = Field(
-        default=None, description="LLM rerank result"
-    )
+    rerank_result: Optional[RerankResult] = Field(default=None, description="LLM rerank result")
     eviction_result: Optional["EvictionResult"] = Field(
         default=None, description="Eviction result if relations exceeded threshold"
     )

--- a/src/vector_graph_rag/rag.py
+++ b/src/vector_graph_rag/rag.py
@@ -5,19 +5,25 @@ Main Vector Graph RAG class with user-friendly API.
 import logging
 import uuid
 from typing import List, Optional
-from tqdm import tqdm
 
-logger = logging.getLogger(__name__)
-
-from vector_graph_rag.config import Settings, get_settings
-from vector_graph_rag.models import Document, Triplet, QueryResult, ExtractionResult, RetrievalDetail, RerankResult, EvictionResult
+from vector_graph_rag.config import Settings
+from vector_graph_rag.graph.builder import GraphBuilder
+from vector_graph_rag.graph.knowledge_graph import SubGraph
+from vector_graph_rag.graph.retriever import GraphRetriever
 from vector_graph_rag.llm.extractor import TripletExtractor
-from vector_graph_rag.llm.reranker import LLMReranker, AnswerGenerator
+from vector_graph_rag.llm.reranker import AnswerGenerator, LLMReranker
+from vector_graph_rag.models import (
+    Document,
+    EvictionResult,
+    ExtractionResult,
+    QueryResult,
+    RerankResult,
+    RetrievalDetail,
+)
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
-from vector_graph_rag.graph.builder import GraphBuilder
-from vector_graph_rag.graph.retriever import GraphRetriever, RetrievalResult
-from vector_graph_rag.graph.knowledge_graph import SubGraph
+
+logger = logging.getLogger(__name__)
 
 
 class VectorGraphRAG:
@@ -171,9 +177,7 @@ class VectorGraphRAG:
         """
         return subgraph.passage_texts
 
-    def _get_passages_from_relations(
-        self, relation_ids: List[str]
-    ) -> tuple[List[str], List[str]]:
+    def _get_passages_from_relations(self, relation_ids: List[str]) -> tuple[List[str], List[str]]:
         """
         Get passages associated with given relations.
 
@@ -313,17 +317,13 @@ class VectorGraphRAG:
         )
 
         relation_embeddings = (
-            self._embedding_model.embed_batch(
-                relation_texts, show_progress=show_progress
-            )
+            self._embedding_model.embed_batch(relation_texts, show_progress=show_progress)
             if relation_texts
             else []
         )
 
         passage_embeddings = (
-            self._embedding_model.embed_batch(
-                passage_texts, show_progress=show_progress
-            )
+            self._embedding_model.embed_batch(passage_texts, show_progress=show_progress)
             if passage_texts
             else []
         )
@@ -332,10 +332,12 @@ class VectorGraphRAG:
         # Entity metadata: relation_ids (directly connected relations), passage_ids
         entity_metadatas = []
         for eid in self._graph_builder.entity_ids:
-            entity_metadatas.append({
-                "relation_ids": self._graph_builder.entity_to_relation_ids.get(eid, []),
-                "passage_ids": self._graph_builder.entity_to_passage_ids.get(eid, []),
-            })
+            entity_metadatas.append(
+                {
+                    "relation_ids": self._graph_builder.entity_to_relation_ids.get(eid, []),
+                    "passage_ids": self._graph_builder.entity_to_passage_ids.get(eid, []),
+                }
+            )
 
         # Relation metadata: entity_ids (head and tail), passage_ids, triplet fields
         relation_metadatas = []
@@ -359,10 +361,12 @@ class VectorGraphRAG:
         # Passage metadata
         passage_metadatas = []
         for pid in self._graph_builder.passage_ids:
-            passage_metadatas.append({
-                "entity_ids": self._graph_builder.passage_to_entity_ids.get(pid, []),
-                "relation_ids": self._graph_builder.passage_to_relation_ids.get(pid, []),
-            })
+            passage_metadatas.append(
+                {
+                    "entity_ids": self._graph_builder.passage_to_entity_ids.get(pid, []),
+                    "relation_ids": self._graph_builder.passage_to_relation_ids.get(pid, []),
+                }
+            )
 
         # Drop and recreate collections for fresh data
         self._store.drop_collections()
@@ -437,15 +441,15 @@ class VectorGraphRAG:
             doc_id = doc_data.get("id") or str(uuid.uuid4())
             # Store triplets in metadata as list of [subject, predicate, object]
             triplets = doc_data.get("triplets", [])
-            docs.append(Document(
-                page_content=passage,
-                metadata={"triplets": triplets},
-                id=doc_id,
-            ))
+            docs.append(
+                Document(
+                    page_content=passage,
+                    metadata={"triplets": triplets},
+                    id=doc_id,
+                )
+            )
 
-        return self.add_documents(
-            docs, extract_triplets=False, show_progress=show_progress
-        )
+        return self.add_documents(docs, extract_triplets=False, show_progress=show_progress)
 
     def query(
         self,
@@ -640,9 +644,7 @@ class VectorGraphRAG:
         passage_ids, passages = self._get_passages_from_relations(reranked_ids)
 
         if len(passages) < top_k:
-            additional_passages = retriever.retrieve_passages_naive(
-                question, top_k=top_k
-            )
+            additional_passages = retriever.retrieve_passages_naive(question, top_k=top_k)
             for passage in additional_passages:
                 if passage not in passages:
                     passages.append(passage)

--- a/src/vector_graph_rag/storage/__init__.py
+++ b/src/vector_graph_rag/storage/__init__.py
@@ -2,8 +2,8 @@
 Storage modules for vector database and embeddings.
 """
 
-from vector_graph_rag.storage.milvus import MilvusStore
 from vector_graph_rag.storage.embeddings import EmbeddingModel
+from vector_graph_rag.storage.milvus import MilvusStore
 
 __all__ = [
     "MilvusStore",

--- a/src/vector_graph_rag/storage/embeddings.py
+++ b/src/vector_graph_rag/storage/embeddings.py
@@ -5,13 +5,13 @@ Supports both HuggingFace models (e.g., facebook/contriever) and OpenAI models.
 Also supports instruction-based models like Qwen3-Embedding and BGE.
 """
 
-from typing import List, Optional, Union, Literal
+from typing import List, Literal, Optional, Union
+
 import numpy as np
 import torch
 from tqdm import tqdm
 
 from vector_graph_rag.config import Settings, get_settings
-
 
 # Predefined instruction templates for different models
 INSTRUCTION_TEMPLATES = {
@@ -50,16 +50,10 @@ def _get_model_family(model_name: str) -> Optional[str]:
     return None
 
 
-def _mean_pooling(
-    token_embeddings: torch.Tensor, attention_mask: torch.Tensor
-) -> torch.Tensor:
+def _mean_pooling(token_embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
     """Mean pooling with attention mask."""
-    token_embeddings = token_embeddings.masked_fill(
-        ~attention_mask[..., None].bool(), 0.0
-    )
-    sentence_embeddings = (
-        token_embeddings.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
-    )
+    token_embeddings = token_embeddings.masked_fill(~attention_mask[..., None].bool(), 0.0)
+    sentence_embeddings = token_embeddings.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
     return sentence_embeddings
 
 
@@ -107,9 +101,7 @@ class HuggingFaceEmbedding:
         template = template_config.get(text_type, "{text}")
         instruction = self.instruction or template_config.get("default_instruction", "")
 
-        return [
-            template.format(instruction=instruction, text=t) for t in texts
-        ]
+        return [template.format(instruction=instruction, text=t) for t in texts]
 
     def encode(
         self,
@@ -135,9 +127,7 @@ class HuggingFaceEmbedding:
                 processed_texts, padding=True, truncation=True, return_tensors="pt", max_length=512
             ).to(self.device)
             outputs = self.model(**inputs)
-            embeddings = _mean_pooling(
-                outputs.last_hidden_state, inputs["attention_mask"]
-            )
+            embeddings = _mean_pooling(outputs.last_hidden_state, inputs["attention_mask"])
 
             if normalize:
                 embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
@@ -328,9 +318,7 @@ class EmbeddingModel:
         all_embeddings = []
 
         batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
-        iterator = (
-            tqdm(batches, desc="Generating embeddings") if show_progress else batches
-        )
+        iterator = tqdm(batches, desc="Generating embeddings") if show_progress else batches
 
         for batch in iterator:
             embeddings = self._backend.encode(batch, text_type=text_type)

--- a/src/vector_graph_rag/storage/milvus.py
+++ b/src/vector_graph_rag/storage/milvus.py
@@ -12,14 +12,15 @@ Users should interact with passages through the Graph abstraction layer.
 
 import logging
 import uuid
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
-logger = logging.getLogger(__name__)
-from pymilvus import MilvusClient, DataType
+from pymilvus import DataType, MilvusClient
 from tqdm import tqdm
 
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.storage.embeddings import EmbeddingModel
+
+logger = logging.getLogger(__name__)
 
 
 def generate_id() -> str:
@@ -67,11 +68,7 @@ class MilvusStore:
         self.client = MilvusClient(**client_kwargs)
 
         # Collection names with optional prefix
-        prefix = (
-            f"{self.settings.collection_prefix}_"
-            if self.settings.collection_prefix
-            else ""
-        )
+        prefix = f"{self.settings.collection_prefix}_" if self.settings.collection_prefix else ""
         self.entity_collection = f"{prefix}{self.settings.entity_collection}"
         self.relation_collection = f"{prefix}{self.settings.relation_collection}"
         self.passage_collection = f"{prefix}{self.settings.passage_collection}"
@@ -83,7 +80,6 @@ class MilvusStore:
         drop_existing: bool = False,
     ) -> None:
         """Create a single collection with standard schema."""
-        from pymilvus import DataType
 
         if self.client.has_collection(collection_name):
             if drop_existing:
@@ -181,9 +177,7 @@ class MilvusStore:
         iterator = range(0, len(ids), batch_size)
 
         if show_progress:
-            iterator = tqdm(
-                iterator, total=total_batches, desc=f"Inserting to {collection_name}"
-            )
+            iterator = tqdm(iterator, total=total_batches, desc=f"Inserting to {collection_name}")
 
         for start_idx in iterator:
             end_idx = min(start_idx + batch_size, len(ids))
@@ -400,7 +394,15 @@ class MilvusStore:
             collection_name=self.relation_collection,
             data=[query_embedding],
             limit=top_k,
-            output_fields=["id", "text", "entity_ids", "passage_ids", "subject", "predicate", "object"],
+            output_fields=[
+                "id",
+                "text",
+                "entity_ids",
+                "passage_ids",
+                "subject",
+                "predicate",
+                "object",
+            ],
         )
         return results[0] if results else []
 
@@ -480,7 +482,15 @@ class MilvusStore:
         results = self.client.query(
             collection_name=self.relation_collection,
             filter=f"id in [{ids_str}]",
-            output_fields=["id", "text", "entity_ids", "passage_ids", "subject", "predicate", "object"],
+            output_fields=[
+                "id",
+                "text",
+                "entity_ids",
+                "passage_ids",
+                "subject",
+                "predicate",
+                "object",
+            ],
         )
         return results
 


### PR DESCRIPTION
## Summary

- Fix all ruff lint warnings (84 issues): import sorting, unused imports/variables, bare excepts, duplicate imports, trailing whitespace
- Apply consistent code formatting with `ruff format` (line-length=100)
- Remove unused `num_select` parameter from `LLMReranker.rerank()`

No functional changes. All existing behavior is preserved.

Developers can run `ruff check src/` and `ruff format src/` locally to maintain code style.