### PR TITLE
fix(frontend): @/utils/cn import within FileUploader.tsx

### DIFF
--- a/frontend/src/components/import/FileUploader.tsx
+++ b/frontend/src/components/import/FileUploader.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Upload, X, File } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { cn } from '@/utils/cn'
 
 interface FileUploaderProps {
   files: File[]


### PR DESCRIPTION
Within `FileUploader.tsx` change the import of the non-existing `@/lib/utils` package to `@/utils/cn`, to make the frontend build succeed.

Otherwise running `npm run build` within the frontend directory fails with
```
src/components/import/FileUploader.tsx:4:20 - error TS2307: Cannot find module '@/lib/utils' or its corresponding type declarations.

4 import { cn } from '@/lib/utils'
                     ~~~~~~~~~~~~~
```