### PR TITLE
Support document metadata filters

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -155,6 +155,9 @@ def add_texts(
 result = rag.add_texts([
     "Albert Einstein developed the theory of general relativity.",
     "Einstein was born in Ulm, Germany in 1879.",
+], metadatas=[
+    {"source": "physics", "year": 1915},
+    {"source": "biography", "year": 1879},
 ])
 
 print(f"Extracted {len(result.entities)} entities, {len(result.relations)} relations")
@@ -207,6 +210,7 @@ def add_documents_with_triplets(
 ```
 
 Each dict in `documents` should contain the document text and its pre-extracted triplets.
+Optional `metadata` is stored on the passage and can be used by query filters.
 
 **Returns:** [`ExtractionResult`](#extractionresult)
 
@@ -218,6 +222,7 @@ Each dict in `documents` should contain the document text and its pre-extracted 
             "triplets": [
                 ("Albert Einstein", "developed", "theory of general relativity"),
             ],
+            "metadata": {"source": "physics", "year": 1915},
         },
     ]
 
@@ -240,6 +245,7 @@ def query(
     entity_similarity_threshold: Optional[float] = None,
     relation_similarity_threshold: Optional[float] = None,
     expansion_degree: Optional[int] = None,
+    filter: Optional[str] = None,
 ) -> QueryResult
 ```
 
@@ -253,6 +259,7 @@ def query(
 | `entity_similarity_threshold` | Override `Settings.entity_similarity_threshold` for this query. |
 | `relation_similarity_threshold` | Override `Settings.relation_similarity_threshold` for this query. |
 | `expansion_degree` | Override `Settings.expansion_degree` for this query. |
+| `filter` | Optional Milvus filter expression applied to passage metadata. |
 
 **Returns:** [`QueryResult`](#queryresult)
 
@@ -261,6 +268,13 @@ result = rag.query("What did Einstein contribute to physics?")
 
 print(result.answer)
 print(f"Found {len(result.passages)} relevant passages")
+```
+
+```python
+result = rag.query(
+    "What did Einstein contribute to physics?",
+    filter='source == "physics" and year >= 1900',
+)
 ```
 
 !!! tip "Per-query tuning"
@@ -284,7 +298,7 @@ print(f"Found {len(result.passages)} relevant passages")
 A convenience method that returns just the answer string — no metadata, no retrieval details.
 
 ```python
-def query_simple(question: str) -> str
+def query_simple(question: str, filter: Optional[str] = None) -> str
 ```
 
 **Returns:** `str` — the generated answer.
@@ -302,7 +316,7 @@ print(answer)
 Run a **naive vector-only** retrieval (no graph expansion or reranking). Useful as a baseline for comparison.
 
 ```python
-def query_naive(question: str) -> QueryResult
+def query_naive(question: str, filter: Optional[str] = None) -> QueryResult
 ```
 
 **Returns:** [`QueryResult`](#queryresult)
@@ -326,6 +340,7 @@ def retrieve(
     question: str,
     use_reranking: bool = True,
     top_k: Optional[int] = None,
+    filter: Optional[str] = None,
 ) -> QueryResult
 ```
 
@@ -334,6 +349,7 @@ def retrieve(
 | `question` | The natural-language question. |
 | `use_reranking` | Whether to apply LLM-based reranking. |
 | `top_k` | Number of passages to return (overrides `Settings.final_top_k`). |
+| `filter` | Optional Milvus filter expression applied to passage metadata. |
 
 **Returns:** [`QueryResult`](#queryresult) (with `answer` field empty or `None`).
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -169,6 +169,10 @@ Adds documents to a graph. Optionally extracts knowledge graph triplets from the
     "Einstein developed the theory of relativity."
   ],
   "ids": ["doc_1", "doc_2"],
+  "metadatas": [
+    {"source": "biography", "year": 1879},
+    {"source": "physics", "year": 1915}
+  ],
   "extract_triplets": true,
   "triplets": null
 }
@@ -178,6 +182,7 @@ Adds documents to a graph. Optionally extracts knowledge graph triplets from the
 |---|---|---|---|
 | `documents` | `string[]` | Yes | List of document texts to add. |
 | `ids` | `string[]` | No | Custom IDs for the documents. Auto-generated if omitted. |
+| `metadatas` | `object[]` | No | Custom metadata per document. These fields can be used by Milvus filters during query. |
 | `extract_triplets` | `boolean` | No | Whether to extract triplets via LLM. Defaults to `true`. |
 | `triplets` | `string[][][]` | No | Pre-extracted triplets per document. Each triplet is `["subject", "predicate", "object"]`. |
 
@@ -202,6 +207,7 @@ curl -X POST "http://localhost:8000/add_documents?graph_name=my_graph" \
   -H "Content-Type: application/json" \
   -d '{
     "documents": ["Albert Einstein was born in Ulm, Germany in 1879."],
+    "metadatas": [{"source": "biography", "year": 1879}],
     "extract_triplets": true
   }'
 ```
@@ -433,7 +439,8 @@ Performs retrieval-augmented generation over the knowledge graph. The system ret
   "use_reranking": true,
   "entity_top_k": 20,
   "relation_top_k": 20,
-  "expansion_degree": 1
+  "expansion_degree": 1,
+  "filter": "source == \"physics\" and year >= 1900"
 }
 ```
 
@@ -444,6 +451,7 @@ Performs retrieval-augmented generation over the knowledge graph. The system ret
 | `entity_top_k` | `integer` | No | `20` | Number of top entities to retrieve via vector search. |
 | `relation_top_k` | `integer` | No | `20` | Number of top relations to retrieve via vector search. |
 | `expansion_degree` | `integer` | No | `1` | Number of hops for graph neighborhood expansion. |
+| `filter` | `string` | No | `null` | Optional Milvus filter expression applied to document metadata. |
 
 !!! info "Expansion Degree"
     The `expansion_degree` parameter controls how many hops outward from the initially retrieved entities the system will traverse. A value of `1` means direct neighbors are included; `2` means neighbors-of-neighbors, and so on. Higher values retrieve more context but increase latency.
@@ -552,7 +560,8 @@ curl -X POST "http://localhost:8000/query?graph_name=my_graph" \
     "use_reranking": true,
     "entity_top_k": 20,
     "relation_top_k": 20,
-    "expansion_degree": 1
+    "expansion_degree": 1,
+    "filter": "source == \"physics\""
   }'
 ```
 

--- a/src/vector_graph_rag/api/app.py
+++ b/src/vector_graph_rag/api/app.py
@@ -64,6 +64,10 @@ class AddDocumentsRequest(BaseModel):
 
     documents: List[str] = Field(..., description="List of document texts")
     ids: Optional[List[str]] = Field(default=None, description="Optional list of document IDs")
+    metadatas: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Optional metadata for each document",
+    )
     extract_triplets: bool = Field(
         default=True, description="Whether to extract triplets using LLM"
     )
@@ -118,6 +122,10 @@ class QueryRequest(BaseModel):
         default=None, description="Number of relations to retrieve"
     )
     expansion_degree: Optional[int] = Field(default=None, description="Subgraph expansion degree")
+    filter: Optional[str] = Field(
+        default=None,
+        description="Optional Milvus filter expression for document metadata",
+    )
 
 
 class EntitySchema(BaseModel):
@@ -453,6 +461,8 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 }
                 if request.ids and i < len(request.ids):
                     doc_data["id"] = request.ids[i]
+                if request.metadatas and i < len(request.metadatas):
+                    doc_data["metadata"] = request.metadatas[i]
                 documents_with_triplets.append(doc_data)
 
             result = rag.add_documents_with_triplets(documents_with_triplets, show_progress=False)
@@ -460,6 +470,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             result = rag.add_texts(
                 request.documents,
                 ids=request.ids,
+                metadatas=request.metadatas,
                 extract_triplets=request.extract_triplets,
                 show_progress=False,
             )
@@ -619,6 +630,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
             entity_top_k=request.entity_top_k,
             relation_top_k=request.relation_top_k,
             expansion_degree=request.expansion_degree,
+            filter=request.filter,
         )
 
         # Convert subgraph to schema if available

--- a/src/vector_graph_rag/graph/retriever.py
+++ b/src/vector_graph_rag/graph/retriever.py
@@ -4,7 +4,7 @@ Graph-based retriever using vector similarity search.
 
 import logging
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List, Optional, Set, Tuple
 
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.graph.builder import GraphBuilder
@@ -251,6 +251,9 @@ class GraphRetriever:
         """
         before_count = len(expanded_relation_ids)
 
+        if before_count == 0:
+            return [], [], False, 0
+
         if before_count <= relation_number_threshold:
             # No eviction needed, fetch all relation texts
             ids_str = ", ".join(f'"{rid}"' for rid in expanded_relation_ids)
@@ -285,6 +288,58 @@ class GraphRetriever:
 
         return filtered_ids, filtered_texts, True, before_count
 
+    def _get_allowed_passage_ids(self, filter: Optional[str]) -> Optional[Set[str]]:
+        """Return passage IDs matching a metadata filter, or None when no filter is set."""
+        if not filter:
+            return None
+        return set(self.store.query_passage_ids(filter))
+
+    def _filter_relations_by_passage_ids(
+        self,
+        relation_ids: List[str],
+        allowed_passage_ids: Optional[Set[str]],
+    ) -> List[str]:
+        """Keep relations that point to at least one allowed passage."""
+        if allowed_passage_ids is None:
+            return relation_ids
+        if not relation_ids or not allowed_passage_ids:
+            return []
+
+        relation_data = self.store._get_relations_by_ids(relation_ids)
+        allowed_relation_ids = {
+            r["id"]
+            for r in relation_data
+            if set(r.get("passage_ids", [])) & allowed_passage_ids
+        }
+        return [rid for rid in relation_ids if rid in allowed_relation_ids]
+
+    def _filter_relation_results_by_passage_ids(
+        self,
+        relation_ids: List[str],
+        relation_texts: List[str],
+        relation_scores: List[float],
+        allowed_passage_ids: Optional[Set[str]],
+    ) -> Tuple[List[str], List[str], List[float]]:
+        """Filter parallel relation result lists using allowed passage IDs."""
+        filtered_ids = self._filter_relations_by_passage_ids(
+            relation_ids,
+            allowed_passage_ids,
+        )
+        if filtered_ids is relation_ids:
+            return relation_ids, relation_texts, relation_scores
+
+        allowed = set(filtered_ids)
+        kept_ids: List[str] = []
+        kept_texts: List[str] = []
+        kept_scores: List[float] = []
+        for rid, text, score in zip(relation_ids, relation_texts, relation_scores):
+            if rid in allowed:
+                kept_ids.append(rid)
+                kept_texts.append(text)
+                kept_scores.append(score)
+
+        return kept_ids, kept_texts, kept_scores
+
     def retrieve(
         self,
         query: str,
@@ -294,6 +349,7 @@ class GraphRetriever:
         relation_similarity_threshold: Optional[float] = None,
         expansion_degree: Optional[int] = None,
         relation_number_threshold: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> RetrievalResult:
         """
         Perform graph-based retrieval for a query.
@@ -313,11 +369,14 @@ class GraphRetriever:
             relation_similarity_threshold: Override relation similarity threshold.
             expansion_degree: Override expansion degree.
             relation_number_threshold: Override relation number threshold for eviction.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             RetrievalResult with all retrieval information, including
             the SubGraph for debugging/visualization.
         """
+        allowed_passage_ids = self._get_allowed_passage_ids(filter)
+
         # Extract query entities
         query_entities = self._extract_query_entities(query)
 
@@ -334,15 +393,27 @@ class GraphRetriever:
             top_k=relation_top_k,
             similarity_threshold=relation_similarity_threshold,
         )
+        relation_ids, relation_texts, relation_scores = (
+            self._filter_relation_results_by_passage_ids(
+                relation_ids,
+                relation_texts,
+                relation_scores,
+                allowed_passage_ids,
+            )
+        )
 
         # Expand subgraph
         subgraph = self._expand_subgraph(entity_ids, relation_ids, degree=expansion_degree)
 
         # Apply eviction strategy if needed
         threshold = relation_number_threshold or self.settings.relation_number_threshold
+        filtered_expanded_relation_ids = self._filter_relations_by_passage_ids(
+            list(subgraph.relation_ids),
+            allowed_passage_ids,
+        )
         expanded_ids, expanded_texts, eviction_occurred, eviction_before = self._apply_eviction(
             query,
-            list(subgraph.relation_ids),
+            filtered_expanded_relation_ids,
             threshold,
         )
 
@@ -367,6 +438,7 @@ class GraphRetriever:
         self,
         query: str,
         top_k: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> List[str]:
         """
         Naive RAG passage retrieval for comparison.
@@ -374,11 +446,12 @@ class GraphRetriever:
         Args:
             query: The query text.
             top_k: Number of passages to return.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             List of passage texts.
         """
         top_k = top_k or self.settings.final_top_k
         query_embedding = self.embedding_model.embed(query)
-        results = self.store.search_passages(query_embedding, top_k=top_k)
+        results = self.store.search_passages(query_embedding, top_k=top_k, filter=filter)
         return [r["entity"]["text"] for r in results]

--- a/src/vector_graph_rag/rag.py
+++ b/src/vector_graph_rag/rag.py
@@ -4,7 +4,7 @@ Main Vector Graph RAG class with user-friendly API.
 
 import logging
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from vector_graph_rag.config import Settings
 from vector_graph_rag.graph.builder import GraphBuilder
@@ -177,12 +177,36 @@ class VectorGraphRAG:
         """
         return subgraph.passage_texts
 
-    def _get_passages_from_relations(self, relation_ids: List[str]) -> tuple[List[str], List[str]]:
+    @staticmethod
+    def _get_user_passage_metadata(doc: Document) -> Dict[str, Any]:
+        """Return user metadata that can be stored on passage records."""
+        metadata = dict(doc.metadata or {})
+        metadata.pop("triplets", None)
+        return metadata
+
+    @staticmethod
+    def _merge_passage_metadata(
+        user_metadata: Dict[str, Any],
+        entity_ids: List[str],
+        relation_ids: List[str],
+    ) -> Dict[str, Any]:
+        """Merge user metadata with internal graph adjacency fields."""
+        metadata = dict(user_metadata)
+        metadata["entity_ids"] = entity_ids
+        metadata["relation_ids"] = relation_ids
+        return metadata
+
+    def _get_passages_from_relations(
+        self,
+        relation_ids: List[str],
+        filter: Optional[str] = None,
+    ) -> tuple[List[str], List[str]]:
         """
         Get passages associated with given relations.
 
         Args:
             relation_ids: List of relation IDs (strings).
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             Tuple of (passage_ids, passage_texts).
@@ -204,10 +228,11 @@ class VectorGraphRAG:
         if not passage_ids:
             return [], []
 
-        passage_data = self._store.get_passages_by_ids(passage_ids)
+        passage_data = self._store.get_passages_by_ids(passage_ids, filter=filter)
         id_to_text = {p["id"]: p["text"] for p in passage_data}
 
         passages = [id_to_text[pid] for pid in passage_ids if pid in id_to_text]
+        passage_ids = [pid for pid in passage_ids if pid in id_to_text]
         return passage_ids, passages
 
     def add_texts(
@@ -358,14 +383,21 @@ class VectorGraphRAG:
 
             relation_metadatas.append(metadata)
 
+        passage_user_metadatas = {
+            doc.id: self._get_user_passage_metadata(doc)
+            for doc in documents
+            if doc.id is not None
+        }
+
         # Passage metadata
         passage_metadatas = []
         for pid in self._graph_builder.passage_ids:
             passage_metadatas.append(
-                {
-                    "entity_ids": self._graph_builder.passage_to_entity_ids.get(pid, []),
-                    "relation_ids": self._graph_builder.passage_to_relation_ids.get(pid, []),
-                }
+                self._merge_passage_metadata(
+                    passage_user_metadatas.get(pid, {}),
+                    self._graph_builder.passage_to_entity_ids.get(pid, []),
+                    self._graph_builder.passage_to_relation_ids.get(pid, []),
+                )
             )
 
         # Drop and recreate collections for fresh data
@@ -437,14 +469,18 @@ class VectorGraphRAG:
         """
         docs = []
         for doc_data in documents:
-            passage = doc_data["passage"]
+            passage = doc_data.get("passage", doc_data.get("text"))
+            if passage is None:
+                raise ValueError('Each document must include "passage" or "text".')
             doc_id = doc_data.get("id") or str(uuid.uuid4())
             # Store triplets in metadata as list of [subject, predicate, object]
             triplets = doc_data.get("triplets", [])
+            metadata = dict(doc_data.get("metadata") or {})
+            metadata["triplets"] = triplets
             docs.append(
                 Document(
                     page_content=passage,
-                    metadata={"triplets": triplets},
+                    metadata=metadata,
                     id=doc_id,
                 )
             )
@@ -461,6 +497,7 @@ class VectorGraphRAG:
         entity_similarity_threshold: Optional[float] = None,
         relation_similarity_threshold: Optional[float] = None,
         expansion_degree: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> QueryResult:
         """
         Query the knowledge base.
@@ -482,6 +519,7 @@ class VectorGraphRAG:
             entity_similarity_threshold: Override entity similarity threshold.
             relation_similarity_threshold: Override relation similarity threshold.
             expansion_degree: Override expansion degree.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             QueryResult with answer, retrieval details, and subgraph for visualization.
@@ -501,6 +539,7 @@ class VectorGraphRAG:
             entity_similarity_threshold=entity_similarity_threshold,
             relation_similarity_threshold=relation_similarity_threshold,
             expansion_degree=expansion_degree,
+            filter=filter,
         )
 
         # Build retrieval detail for visualization
@@ -532,7 +571,7 @@ class VectorGraphRAG:
             reranked_texts = candidate_texts[: self.settings.final_top_k]
 
         # Get passages from reranked relations
-        passage_ids, passages = self._get_passages_from_relations(reranked_ids)
+        passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
         final_passages = passages[: self.settings.final_top_k]
 
         # Generate answer
@@ -560,12 +599,13 @@ class VectorGraphRAG:
             eviction_result=eviction_result,
         )
 
-    def query_simple(self, question: str) -> str:
+    def query_simple(self, question: str, filter: Optional[str] = None) -> str:
         """
         Simple query that returns just the answer.
 
         Args:
             question: The question to answer.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             The answer string.
@@ -574,9 +614,9 @@ class VectorGraphRAG:
             >>> answer = rag.query_simple("What did Einstein develop?")
             >>> print(answer)
         """
-        return self.query(question).answer
+        return self.query(question, filter=filter).answer
 
-    def query_naive(self, question: str) -> QueryResult:
+    def query_naive(self, question: str, filter: Optional[str] = None) -> QueryResult:
         """
         Query using naive RAG (direct passage retrieval).
 
@@ -584,12 +624,13 @@ class VectorGraphRAG:
 
         Args:
             question: The question to answer.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             QueryResult with answer and retrieved passages.
         """
         retriever = self._ensure_retriever()
-        passages = retriever.retrieve_passages_naive(question)
+        passages = retriever.retrieve_passages_naive(question, filter=filter)
         answer = self._answer_generator.generate(question, passages)
 
         return QueryResult(
@@ -606,6 +647,7 @@ class VectorGraphRAG:
         question: str,
         use_reranking: bool = True,
         top_k: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> QueryResult:
         """
         Retrieve passages using Graph RAG without generating an answer.
@@ -617,6 +659,7 @@ class VectorGraphRAG:
             question: The question to answer.
             use_reranking: Whether to use LLM reranking.
             top_k: Number of passages to retrieve. Uses settings.final_top_k if not provided.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             QueryResult with retrieved passages (answer will be empty).
@@ -625,7 +668,7 @@ class VectorGraphRAG:
         top_k = top_k or self.settings.final_top_k
 
         # Retrieve
-        retrieval_result = retriever.retrieve(question)
+        retrieval_result = retriever.retrieve(question, filter=filter)
 
         # Get candidate relations
         candidate_ids = retrieval_result.expanded_relation_ids
@@ -641,10 +684,14 @@ class VectorGraphRAG:
             reranked_texts = candidate_texts[:top_k]
 
         # Get passages from reranked relations
-        passage_ids, passages = self._get_passages_from_relations(reranked_ids)
+        passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
 
         if len(passages) < top_k:
-            additional_passages = retriever.retrieve_passages_naive(question, top_k=top_k)
+            additional_passages = retriever.retrieve_passages_naive(
+                question,
+                top_k=top_k,
+                filter=filter,
+            )
             for passage in additional_passages:
                 if passage not in passages:
                     passages.append(passage)
@@ -665,6 +712,7 @@ class VectorGraphRAG:
         self,
         question: str,
         top_k: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> QueryResult:
         """
         Retrieve passages using naive RAG without generating an answer.
@@ -675,13 +723,14 @@ class VectorGraphRAG:
         Args:
             question: The question to answer.
             top_k: Number of passages to retrieve. Uses settings.final_top_k if not provided.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             QueryResult with retrieved passages (answer will be empty).
         """
         retriever = self._ensure_retriever()
         top_k = top_k or self.settings.final_top_k
-        passages = retriever.retrieve_passages_naive(question, top_k=top_k)
+        passages = retriever.retrieve_passages_naive(question, top_k=top_k, filter=filter)
 
         return QueryResult(
             query=question,

--- a/src/vector_graph_rag/storage/milvus.py
+++ b/src/vector_graph_rag/storage/milvus.py
@@ -73,6 +73,12 @@ class MilvusStore:
         self.relation_collection = f"{prefix}{self.settings.relation_collection}"
         self.passage_collection = f"{prefix}{self.settings.passage_collection}"
 
+    @staticmethod
+    def _combine_filters(*filters: Optional[str]) -> str:
+        """Combine non-empty Milvus filter expressions with AND."""
+        parts = [f.strip() for f in filters if f and f.strip()]
+        return " and ".join(f"({part})" for part in parts)
+
     def _create_collection(
         self,
         collection_name: str,
@@ -410,6 +416,7 @@ class MilvusStore:
         self,
         query_embedding: List[float],
         top_k: Optional[int] = None,
+        filter: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Search for similar passages (naive RAG).
@@ -417,6 +424,7 @@ class MilvusStore:
         Args:
             query_embedding: Query embedding vector.
             top_k: Number of results to return.
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             List of search results with id (str) and text.
@@ -427,6 +435,7 @@ class MilvusStore:
             collection_name=self.passage_collection,
             data=[query_embedding],
             limit=top_k,
+            filter=filter,
             output_fields=["id", "text", "entity_ids", "relation_ids"],
         )
         return results[0] if results else []
@@ -497,12 +506,14 @@ class MilvusStore:
     def get_passages_by_ids(
         self,
         passage_ids: List[str],
+        filter: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Get passages by their IDs.
 
         Args:
             passage_ids: List of passage IDs (strings).
+            filter: Optional Milvus filter expression for passage metadata.
 
         Returns:
             List of passage data with id, text, entity_ids, and relation_ids.
@@ -512,12 +523,33 @@ class MilvusStore:
 
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{pid}"' for pid in passage_ids)
+        filter_expr = self._combine_filters(f"id in [{ids_str}]", filter)
         results = self.client.query(
             collection_name=self.passage_collection,
-            filter=f"id in [{ids_str}]",
+            filter=filter_expr,
             output_fields=["id", "text", "entity_ids", "relation_ids"],
         )
         return results
+
+    def query_passage_ids(self, filter: str) -> List[str]:
+        """
+        Query passage IDs that match a Milvus filter expression.
+
+        Args:
+            filter: Milvus filter expression for passage metadata.
+
+        Returns:
+            Matching passage IDs.
+        """
+        if not filter or not filter.strip():
+            return []
+
+        results = self.client.query(
+            collection_name=self.passage_collection,
+            filter=filter,
+            output_fields=["id"],
+        )
+        return [r["id"] for r in results]
 
     # ==================== Update Operations ====================
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,11 @@
 """Tests for API endpoints."""
 
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock, patch
-import tempfile
-import os
 
 from vector_graph_rag.api.app import create_app
 from vector_graph_rag.config import Settings
@@ -134,6 +135,7 @@ class TestAddDocumentsEndpoint:
             "/add_documents",
             json={
                 "documents": ["Test document 1", "Test document 2"],
+                "metadatas": [{"source": "test1"}, {"source": "test2"}],
                 "extract_triplets": False,
             },
         )
@@ -141,6 +143,8 @@ class TestAddDocumentsEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "num_documents" in data
+        args, _ = mock_add.call_args
+        assert args[0][0].metadata == {"source": "test1"}
 
 
 class TestQueryEndpoint:
@@ -162,10 +166,12 @@ class TestQueryEndpoint:
 
         response = client.post(
             "/query",
-            json={"question": "Test question"},
+            json={"question": "Test question", "filter": 'source == "test"'},
         )
 
         assert response.status_code == 200
         data = response.json()
-        assert data["query"] == "Test question"
+        assert data["question"] == "Test question"
         assert "answer" in data
+        _, kwargs = mock_query.call_args
+        assert kwargs["filter"] == 'source == "test"'

--- a/tests/test_milvus_store.py
+++ b/tests/test_milvus_store.py
@@ -1,9 +1,8 @@
 """Tests for MilvusStore CRUD operations."""
 
-import pytest
 import uuid
 
-from vector_graph_rag.storage.milvus import MilvusStore, generate_id
+from vector_graph_rag.storage.milvus import generate_id
 
 
 class TestGenerateId:
@@ -350,3 +349,58 @@ class TestMilvusStoreSearch:
         )
 
         assert len(results) >= 1
+
+    def test_search_passages_with_metadata_filter(self, milvus_store):
+        """Test searching passages with a Milvus metadata filter."""
+        ids = ["physics_doc", "biology_doc"]
+        milvus_store.insert_passages(
+            ["First document about physics.", "Second document about biology."],
+            ids=ids,
+            embeddings=[[0.1] * 1536, [0.1] * 1536],
+            metadatas=[
+                {"source": "physics", "tenant_id": "team_a"},
+                {"source": "biology", "tenant_id": "team_b"},
+            ],
+        )
+
+        results = milvus_store.search_passages(
+            [0.1] * 1536,
+            top_k=2,
+            filter='tenant_id == "team_a"',
+        )
+
+        assert [r["entity"]["id"] for r in results] == ["physics_doc"]
+
+    def test_get_passages_by_ids_with_metadata_filter(self, milvus_store):
+        """Test retrieving passages by IDs with an additional metadata filter."""
+        ids = ["doc_a", "doc_b"]
+        milvus_store.insert_passages(
+            ["Tenant A document.", "Tenant B document."],
+            ids=ids,
+            embeddings=[[0.1] * 1536, [0.1] * 1536],
+            metadatas=[
+                {"tenant_id": "team_a"},
+                {"tenant_id": "team_b"},
+            ],
+        )
+
+        results = milvus_store.get_passages_by_ids(ids, filter='tenant_id == "team_b"')
+
+        assert len(results) == 1
+        assert results[0]["id"] == "doc_b"
+
+    def test_query_passage_ids_with_metadata_filter(self, milvus_store):
+        """Test querying passage IDs by custom metadata."""
+        milvus_store.insert_passages(
+            ["Tenant A document.", "Tenant B document."],
+            ids=["doc_a", "doc_b"],
+            embeddings=[[0.1] * 1536, [0.1] * 1536],
+            metadatas=[
+                {"tenant_id": "team_a"},
+                {"tenant_id": "team_b"},
+            ],
+        )
+
+        ids = milvus_store.query_passage_ids('tenant_id == "team_a"')
+
+        assert ids == ["doc_a"]

--- a/tests/test_rag_metadata_filter.py
+++ b/tests/test_rag_metadata_filter.py
@@ -1,0 +1,158 @@
+"""End-to-end tests for metadata filtering in VectorGraphRAG."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from vector_graph_rag.config import Settings
+from vector_graph_rag.graph.retriever import GraphRetriever
+from vector_graph_rag.models import Document
+from vector_graph_rag.rag import VectorGraphRAG
+
+
+class FakeEmbeddingModel:
+    """Small deterministic embedding model for Milvus Lite tests."""
+
+    dimension = 4
+
+    def embed(self, text: str, text_type: str = "query") -> list[float]:
+        text = text.lower()
+        if "alpha" in text or "blue" in text:
+            return [1.0, 0.0, 0.0, 0.0]
+        if "beta" in text or "red" in text:
+            return [0.0, 1.0, 0.0, 0.0]
+        return [0.5, 0.5, 0.0, 0.0]
+
+    def embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int | None = None,
+        show_progress: bool = False,
+        text_type: str = "query",
+    ) -> list[list[float]]:
+        return [self.embed(text, text_type=text_type) for text in texts]
+
+
+class FakeEntityExtractor:
+    """Deterministic entity extractor for query-time graph retrieval."""
+
+    def extract(self, question: str) -> list[str]:
+        return ["alpha"]
+
+
+def create_test_rag(milvus_uri: str, collection_prefix: str) -> VectorGraphRAG:
+    """Create a VectorGraphRAG instance with fake embeddings and no LLM calls."""
+    settings = Settings(
+        milvus_uri=milvus_uri,
+        openai_api_key="test-api-key",
+        collection_prefix=collection_prefix,
+        final_top_k=3,
+    )
+    fake_embedding = FakeEmbeddingModel()
+
+    with patch("vector_graph_rag.rag.EmbeddingModel", return_value=fake_embedding):
+        rag = VectorGraphRAG(settings=settings)
+
+    rag._answer_generator.generate = MagicMock(
+        side_effect=lambda question, passages: "\n".join(passages)
+    )
+    return rag
+
+
+def test_add_texts_stores_custom_metadata():
+    """Store metadata passed through add_texts."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        milvus_uri = f.name
+
+    try:
+        rag = create_test_rag(milvus_uri, "metadata_filter_add_texts")
+
+        rag.add_texts(
+            ["Alpha metadata passage."],
+            ids=["doc_alpha"],
+            metadatas=[{"tenant_id": "team_a", "source": "add_texts"}],
+            extract_triplets=False,
+            show_progress=False,
+        )
+
+        assert rag._store.query_passage_ids('source == "add_texts"') == ["doc_alpha"]
+    finally:
+        if os.path.exists(milvus_uri):
+            os.unlink(milvus_uri)
+
+
+def test_add_documents_stores_custom_metadata():
+    """Store metadata passed through Document.metadata."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        milvus_uri = f.name
+
+    try:
+        rag = create_test_rag(milvus_uri, "metadata_filter_add_documents")
+
+        rag.add_documents(
+            [
+                Document(
+                    page_content="Alpha document metadata passage.",
+                    metadata={"tenant_id": "team_a", "source": "add_documents"},
+                    id="doc_alpha",
+                )
+            ],
+            extract_triplets=False,
+            show_progress=False,
+        )
+
+        assert rag._store.query_passage_ids('source == "add_documents"') == ["doc_alpha"]
+    finally:
+        if os.path.exists(milvus_uri):
+            os.unlink(milvus_uri)
+
+
+def test_query_filter_uses_custom_metadata_end_to_end():
+    """Store document metadata and use it to filter graph query results."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        milvus_uri = f.name
+
+    try:
+        rag = create_test_rag(milvus_uri, "metadata_filter_e2e")
+
+        rag.add_documents_with_triplets(
+            [
+                {
+                    "id": "doc_alpha",
+                    "passage": "Alpha owns the blue database.",
+                    "triplets": [["Alpha", "owns", "blue database"]],
+                    "metadata": {"tenant_id": "team_a", "source": "alpha_source"},
+                },
+                {
+                    "id": "doc_beta",
+                    "passage": "Alpha owns the red database.",
+                    "triplets": [["Alpha", "owns", "red database"]],
+                    "metadata": {"tenant_id": "team_b", "source": "beta_source"},
+                },
+            ],
+            show_progress=False,
+        )
+        rag._retriever = GraphRetriever(
+            store=rag._store,
+            graph_builder=rag._graph_builder,
+            settings=rag.settings,
+            embedding_model=rag._embedding_model,
+            entity_extractor=FakeEntityExtractor(),
+        )
+
+        stored = rag._store.get_passages_by_ids(["doc_alpha", "doc_beta"])
+        assert len(stored) == 2
+        assert set(rag._store.query_passage_ids('tenant_id == "team_a"')) == {"doc_alpha"}
+
+        result = rag.query(
+            "What database does Alpha own?",
+            use_reranking=False,
+            filter='tenant_id == "team_a"',
+        )
+
+        assert result.passages == ["Alpha owns the blue database."]
+        assert result.retrieved_passages == ["Alpha owns the blue database."]
+        assert "red database" not in result.answer
+    finally:
+        if os.path.exists(milvus_uri):
+            os.unlink(milvus_uri)


### PR DESCRIPTION
## Summary
- Preserve custom document metadata when adding texts, LangChain documents, or pre-extracted triplets
- Add passage metadata filter support to graph and naive query/retrieve paths
- Expose metadata and filter parameters in the REST API and docs

Closes #33

## Tests
- uv run pytest
- uv run mkdocs build --strict