### PR TITLE
Optimize incremental graph updates

### DIFF
--- a/src/vector_graph_rag/rag.py
+++ b/src/vector_graph_rag/rag.py
@@ -233,7 +233,7 @@ class VectorGraphRAG:
     def _normalize_source_value(value: Any, field_name: str) -> str:
         """Validate and normalize a source metadata value."""
         if not isinstance(value, str) or not value.strip():
-            raise ValueError(f'{field_name} must be a non-empty string.')
+            raise ValueError(f"{field_name} must be a non-empty string.")
         return value.strip()
 
     @staticmethod
@@ -277,7 +277,7 @@ class VectorGraphRAG:
             if conflicting_sources:
                 conflicts = ", ".join(sorted(conflicting_sources))
                 raise ValueError(
-                    f'documents contain {source_field} values that differ from source '
+                    f"documents contain {source_field} values that differ from source "
                     f'"{explicit_source}": {conflicts}'
                 )
             return explicit_source
@@ -520,9 +520,7 @@ class VectorGraphRAG:
         )
         for passage in existing_passages:
             if passage.get(source_field) != source:
-                raise ValueError(
-                    f'Passage ID "{passage["id"]}" already belongs to another source.'
-                )
+                raise ValueError(f'Passage ID "{passage["id"]}" already belongs to another source.')
 
         if show_progress:
             logger.info("Upserting incremental graph into Milvus...")
@@ -534,6 +532,7 @@ class VectorGraphRAG:
         entity_insert_texts: List[str] = []
         entity_insert_embeddings: List[List[float]] = []
         entity_insert_metadatas: List[Dict[str, Any]] = []
+        entity_update_records: List[Dict[str, Any]] = []
 
         for index, eid in enumerate(builder.entity_ids):
             stored_id = entity_id_map[eid]
@@ -548,18 +547,29 @@ class VectorGraphRAG:
             }
             existing = existing_entities.get(entity_text_by_id[eid])
             if existing:
-                self._store._update_entity(
-                    stored_id,
-                    text=entity_text_by_id[eid],
-                    embedding=entity_embeddings[index],
-                    relation_ids=self._merge_unique(existing.get("relation_ids", []), relation_ids),
-                    passage_ids=self._merge_unique(existing.get("passage_ids", []), passage_ids),
+                entity_update_records.append(
+                    {
+                        "id": stored_id,
+                        "text": entity_text_by_id[eid],
+                        "vector": entity_embeddings[index],
+                        "relation_ids": self._merge_unique(
+                            existing.get("relation_ids", []),
+                            relation_ids,
+                        ),
+                        "passage_ids": self._merge_unique(
+                            existing.get("passage_ids", []),
+                            passage_ids,
+                        ),
+                    }
                 )
             else:
                 entity_insert_ids.append(stored_id)
                 entity_insert_texts.append(entity_text_by_id[eid])
                 entity_insert_embeddings.append(entity_embeddings[index])
                 entity_insert_metadatas.append(metadata)
+
+        if entity_update_records:
+            self._store._upsert_entity_records(entity_update_records)
 
         if entity_insert_ids:
             self._store._insert_entities(
@@ -574,6 +584,7 @@ class VectorGraphRAG:
         relation_insert_texts: List[str] = []
         relation_insert_embeddings: List[List[float]] = []
         relation_insert_metadatas: List[Dict[str, Any]] = []
+        relation_update_records: List[Dict[str, Any]] = []
 
         for index, rid in enumerate(builder.relation_ids):
             stored_id = relation_id_map[rid]
@@ -594,21 +605,30 @@ class VectorGraphRAG:
 
             existing = existing_relations.get(relation_text_by_id[rid])
             if existing:
-                self._store._update_relation(
-                    stored_id,
-                    text=relation_text_by_id[rid],
-                    embedding=relation_embeddings[index],
-                    entity_ids=entity_ids,
-                    passage_ids=self._merge_unique(existing.get("passage_ids", []), passage_ids),
-                    subject=metadata.get("subject"),
-                    predicate=metadata.get("predicate"),
-                    object_=metadata.get("object"),
-                )
+                update_record = {
+                    "id": stored_id,
+                    "text": relation_text_by_id[rid],
+                    "vector": relation_embeddings[index],
+                    "entity_ids": entity_ids,
+                    "passage_ids": self._merge_unique(
+                        existing.get("passage_ids", []),
+                        passage_ids,
+                    ),
+                }
+                for field in ["subject", "predicate", "object"]:
+                    if metadata.get(field) is not None:
+                        update_record[field] = metadata[field]
+                    elif field in existing:
+                        update_record[field] = existing[field]
+                relation_update_records.append(update_record)
             else:
                 relation_insert_ids.append(stored_id)
                 relation_insert_texts.append(relation_text_by_id[rid])
                 relation_insert_embeddings.append(relation_embeddings[index])
                 relation_insert_metadatas.append(metadata)
+
+        if relation_update_records:
+            self._store._upsert_relation_records(relation_update_records)
 
         if relation_insert_ids:
             self._store._insert_relations(
@@ -1037,6 +1057,8 @@ class VectorGraphRAG:
         )
 
         relations = self._store._get_relations_by_ids(relation_ids)
+        relation_update_records: List[Dict[str, Any]] = []
+        relation_delete_ids: List[str] = []
         deleted_relation_ids: set[str] = set()
         for relation in relations:
             relation_id = relation["id"]
@@ -1045,15 +1067,29 @@ class VectorGraphRAG:
                 removed_passage_ids,
             )
             if new_passage_ids:
-                self._store._update_relation(
-                    relation_id,
-                    passage_ids=new_passage_ids,
-                )
+                update_record = {
+                    "id": relation_id,
+                    "text": relation["text"],
+                    "vector": self._embedding_model.embed(relation["text"]),
+                    "entity_ids": relation.get("entity_ids", []),
+                    "passage_ids": new_passage_ids,
+                }
+                for field in ["subject", "predicate", "object"]:
+                    if field in relation:
+                        update_record[field] = relation[field]
+                relation_update_records.append(update_record)
             else:
-                self._store._delete_relation(relation_id)
+                relation_delete_ids.append(relation_id)
                 deleted_relation_ids.add(relation_id)
 
+        if relation_update_records:
+            self._store._upsert_relation_records(relation_update_records)
+        if relation_delete_ids:
+            self._store._delete_relations(relation_delete_ids)
+
         entities = self._store._get_entities_by_ids(entity_ids)
+        entity_update_records: List[Dict[str, Any]] = []
+        entity_delete_ids: List[str] = []
         for entity in entities:
             entity_id = entity["id"]
             new_passage_ids = self._remove_many(
@@ -1066,13 +1102,22 @@ class VectorGraphRAG:
             )
 
             if new_passage_ids or new_relation_ids:
-                self._store._update_entity(
-                    entity_id,
-                    passage_ids=new_passage_ids,
-                    relation_ids=new_relation_ids,
+                entity_update_records.append(
+                    {
+                        "id": entity_id,
+                        "text": entity["text"],
+                        "vector": self._embedding_model.embed(entity["text"]),
+                        "passage_ids": new_passage_ids,
+                        "relation_ids": new_relation_ids,
+                    }
                 )
             else:
-                self._store._delete_entity(entity_id)
+                entity_delete_ids.append(entity_id)
+
+        if entity_update_records:
+            self._store._upsert_entity_records(entity_update_records)
+        if entity_delete_ids:
+            self._store._delete_entities(entity_delete_ids)
 
         self._store.delete_passages(passage_ids)
         self._retriever = None

--- a/src/vector_graph_rag/storage/milvus.py
+++ b/src/vector_graph_rag/storage/milvus.py
@@ -13,7 +13,7 @@ Users should interact with passages through the Graph abstraction layer.
 import logging
 import re
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from pymilvus import DataType, MilvusClient
 from tqdm import tqdm
@@ -96,6 +96,77 @@ class MilvusStore:
                 "letters, numbers, and underscores, and it must not start with a number."
             )
         return field_name
+
+    def _batch_items(
+        self,
+        items: List[Any],
+        batch_size: Optional[int] = None,
+    ) -> Iterator[List[Any]]:
+        """Yield items in batches using the configured batch size."""
+        effective_batch_size = batch_size or self.settings.batch_size
+        for start_idx in range(0, len(items), effective_batch_size):
+            yield items[start_idx : start_idx + effective_batch_size]
+
+    @staticmethod
+    def _unique_preserve_order(values: List[str]) -> List[str]:
+        """Return unique strings without changing first-seen order."""
+        seen = set()
+        unique_values = []
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            unique_values.append(value)
+        return unique_values
+
+    def _query_by_texts(
+        self,
+        collection_name: str,
+        texts: List[str],
+        output_fields: List[str],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Query records by exact text in batches."""
+        records_by_text: Dict[str, Dict[str, Any]] = {}
+        unique_texts = self._unique_preserve_order(texts)
+        if not unique_texts:
+            return records_by_text
+
+        for batch_texts in self._batch_items(unique_texts):
+            quoted_texts = ", ".join(self._quote_string(text) for text in batch_texts)
+            results = self.client.query(
+                collection_name=collection_name,
+                filter=f"text in [{quoted_texts}]",
+                output_fields=output_fields,
+            )
+            for record in results:
+                text = record.get("text")
+                if isinstance(text, str) and text not in records_by_text:
+                    records_by_text[text] = record
+
+        return records_by_text
+
+    def _upsert_records(
+        self,
+        collection_name: str,
+        records: List[Dict[str, Any]],
+    ) -> None:
+        """Upsert records in batches using the configured batch size."""
+        if not records:
+            return
+
+        for batch_records in self._batch_items(records):
+            self.client.upsert(
+                collection_name=collection_name,
+                data=batch_records,
+            )
+
+    def _upsert_entity_records(self, records: List[Dict[str, Any]]) -> None:
+        """Upsert fully materialized entity records."""
+        self._upsert_records(self.entity_collection, records)
+
+    def _upsert_relation_records(self, records: List[Dict[str, Any]]) -> None:
+        """Upsert fully materialized relation records."""
+        self._upsert_records(self.relation_collection, records)
 
     def _create_collection(
         self,
@@ -500,16 +571,11 @@ class MilvusStore:
         Returns:
             Mapping from entity text to the first matching entity record.
         """
-        entities_by_text: Dict[str, Dict[str, Any]] = {}
-        for text in entity_texts:
-            results = self.client.query(
-                collection_name=self.entity_collection,
-                filter=f"text == {self._quote_string(text)}",
-                output_fields=["id", "text", "relation_ids", "passage_ids"],
-            )
-            if results:
-                entities_by_text[text] = results[0]
-        return entities_by_text
+        return self._query_by_texts(
+            self.entity_collection,
+            entity_texts,
+            output_fields=["id", "text", "relation_ids", "passage_ids"],
+        )
 
     def _get_relations_by_ids(
         self,
@@ -562,24 +628,19 @@ class MilvusStore:
         Returns:
             Mapping from relation text to the first matching relation record.
         """
-        relations_by_text: Dict[str, Dict[str, Any]] = {}
-        for text in relation_texts:
-            results = self.client.query(
-                collection_name=self.relation_collection,
-                filter=f"text == {self._quote_string(text)}",
-                output_fields=[
-                    "id",
-                    "text",
-                    "entity_ids",
-                    "passage_ids",
-                    "subject",
-                    "predicate",
-                    "object",
-                ],
-            )
-            if results:
-                relations_by_text[text] = results[0]
-        return relations_by_text
+        return self._query_by_texts(
+            self.relation_collection,
+            relation_texts,
+            output_fields=[
+                "id",
+                "text",
+                "entity_ids",
+                "passage_ids",
+                "subject",
+                "predicate",
+                "object",
+            ],
+        )
 
     def get_passages_by_ids(
         self,

--- a/tests/test_rag_incremental.py
+++ b/tests/test_rag_incremental.py
@@ -287,6 +287,120 @@ def test_delete_documents_by_source_cascades_and_preserves_shared_graph_records(
         remove_temp_milvus_file(milvus_uri)
 
 
+def test_incremental_exact_text_lookups_are_batched():
+    """Batch exact entity/relation lookups instead of querying one text at a time."""
+    rag, milvus_uri = with_temp_rag("incremental_batched_lookup")
+    rag.settings.batch_size = 2
+
+    try:
+        rag._store._insert_entities(
+            ["alpha", "beta", "gamma"],
+            ids=["entity_alpha", "entity_beta", "entity_gamma"],
+            embeddings=[
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+        )
+        rag._store._insert_relations(
+            [
+                "alpha owns beta",
+                "beta owns gamma",
+                "gamma owns alpha",
+            ],
+            ids=["relation_alpha_beta", "relation_beta_gamma", "relation_gamma_alpha"],
+            embeddings=[
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+        )
+
+        with patch.object(rag._store.client, "query", wraps=rag._store.client.query) as query_spy:
+            entities = rag._store._get_entities_by_texts(
+                ["alpha", "beta", "alpha", "gamma", "missing"]
+            )
+
+        assert set(entities) == {"alpha", "beta", "gamma"}
+        assert query_spy.call_count == 2
+        assert all("text in [" in call.kwargs["filter"] for call in query_spy.call_args_list)
+
+        with patch.object(rag._store.client, "query", wraps=rag._store.client.query) as query_spy:
+            relations = rag._store._get_relations_by_texts(
+                [
+                    "alpha owns beta",
+                    "beta owns gamma",
+                    "alpha owns beta",
+                    "gamma owns alpha",
+                    "missing relation",
+                ]
+            )
+
+        assert set(relations) == {
+            "alpha owns beta",
+            "beta owns gamma",
+            "gamma owns alpha",
+        }
+        assert query_spy.call_count == 2
+        assert all("text in [" in call.kwargs["filter"] for call in query_spy.call_args_list)
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_upsert_documents_by_source_batches_shared_graph_metadata_updates():
+    """Reuse shared graph records without per-record ID lookups on incremental insert."""
+    rag, milvus_uri = with_temp_rag("incremental_batched_upsert")
+
+    try:
+        shared_triplet = [["Alpha", "founded", "Acme"]]
+        rag.upsert_documents_by_source(
+            [doc("Alpha founded Acme in source A.", shared_triplet)],
+            source="file_alpha",
+            extract_triplets=False,
+            show_progress=False,
+        )
+
+        with (
+            patch.object(
+                rag._store,
+                "_get_entities_by_ids",
+                wraps=rag._store._get_entities_by_ids,
+            ) as entity_lookup_spy,
+            patch.object(
+                rag._store,
+                "_get_relations_by_ids",
+                wraps=rag._store._get_relations_by_ids,
+            ) as relation_lookup_spy,
+            patch.object(rag._store.client, "upsert", wraps=rag._store.client.upsert) as upsert_spy,
+        ):
+            rag.upsert_documents_by_source(
+                [doc("Alpha founded Acme in source B.", shared_triplet)],
+                source="file_beta",
+                extract_triplets=False,
+                show_progress=False,
+            )
+
+        assert entity_lookup_spy.call_count == 0
+        assert relation_lookup_spy.call_count == 0
+
+        entity_upserts = [
+            call
+            for call in upsert_spy.call_args_list
+            if call.kwargs["collection_name"] == rag._store.entity_collection
+        ]
+        relation_upserts = [
+            call
+            for call in upsert_spy.call_args_list
+            if call.kwargs["collection_name"] == rag._store.relation_collection
+        ]
+        assert len(entity_upserts) == 1
+        assert len(entity_upserts[0].kwargs["data"]) == 2
+        assert len(relation_upserts) == 1
+        assert len(relation_upserts[0].kwargs["data"]) == 1
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
 def test_upsert_documents_by_source_supports_metadata_filter_query_end_to_end():
     """Use upserted source metadata to filter graph query results."""
     rag, milvus_uri = with_temp_rag("incremental_query_filter")


### PR DESCRIPTION
## Summary
- batch exact text lookups for existing entities and relations during incremental updates
- batch upsert shared entity and relation metadata instead of per-record update calls
- reduce source delete cascade round trips by batching shared record updates and orphan deletes
- add regression coverage for batched lookups and shared graph metadata updates

## Tests
- uv run ruff check src/vector_graph_rag/storage/milvus.py src/vector_graph_rag/rag.py tests/test_rag_incremental.py
- uv run ruff format --check src/vector_graph_rag/storage/milvus.py src/vector_graph_rag/rag.py tests/test_rag_incremental.py
- uv run pytest tests/test_rag_incremental.py -q
- uv run pytest -q (92 passed before Milvus Lite cleanup hang)