### PR TITLE
Add basic ReAct query loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ rag.rebuild_documents_with_triplets([
 </details>
 
 <details>
+<summary>🔎 <b>ReAct query loop</b> — click to expand</summary>
+
+Use `query_react()` when a question may benefit from iterative search. Each
+search step reuses the same Graph RAG retrieval path and returns a trace.
+
+```python
+result = rag.query_react(
+    "Which theory did Einstein develop, and where did he work?",
+    max_steps=3,
+)
+
+print(result.answer)
+
+for step in result.steps:
+    print(step.action, step.query)
+    print(step.observation)
+```
+
+The default `query()` method remains the single-pass Graph RAG path.
+
+</details>
+
+<details>
 <summary>🔄 <b>Incremental document updates</b> — click to expand</summary>
 
 Use `upsert_documents_by_source()` when a source file, message, or page is

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -518,6 +518,52 @@ result = rag.query(
 
 ---
 
+#### `query_react`
+
+Run a basic ReAct loop over Graph RAG retrieval. The planner can issue multiple
+search actions before returning a final answer. Each search action reuses the
+same graph retrieval path as [`retrieve`](#retrieve).
+
+```python
+def query_react(
+    question: str,
+    max_steps: int = 3,
+    use_reranking: bool = True,
+    top_k: Optional[int] = None,
+    filter: Optional[str] = None,
+) -> ReActResult
+```
+
+| Parameter | Description |
+|---|---|
+| `question` | The natural-language question to answer. |
+| `max_steps` | Maximum number of planner steps. |
+| `use_reranking` | Whether each search step applies LLM-based reranking. |
+| `top_k` | Number of passages to retrieve per search step. |
+| `filter` | Optional Milvus filter expression applied to passage metadata. |
+
+**Returns:** [`ReActResult`](#reactresult)
+
+```python
+result = rag.query_react(
+    "Which database does Alpha own, and who maintains it?",
+    max_steps=3,
+)
+
+print(result.answer)
+
+for step in result.steps:
+    print(step.action, step.query)
+    print(step.observation)
+```
+
+!!! note "Basic loop"
+    `query_react()` is a lightweight agentic query path. It does not replace the
+    default single-pass [`query`](#query) method. Use it when a question may
+    benefit from iterative search and you want a step trace.
+
+---
+
 #### `query_simple`
 
 A convenience method that returns just the answer string — no metadata, no retrieval details.
@@ -662,6 +708,41 @@ print(f"Retrieved {len(result.retrieved_relations)} relations")
 print(f"Expanded to {len(result.expanded_relations)} relations via graph")
 print(f"Final passages: {len(result.passages)}")
 ```
+
+---
+
+## ReActResult
+
+A data class returned by `query_react()`. It contains the final answer and the
+step trace for the ReAct loop.
+
+```python
+from vector_graph_rag import ReActResult
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `query` | `str` | The original question. |
+| `answer` | `str` | The final answer. |
+| `steps` | `list[ReActStep]` | Search and finish actions taken by the planner. |
+| `passages` | `list[str]` | Unique passages observed across search steps. |
+| `relations` | `list[str]` | Unique relations observed across search steps. |
+| `finished` | `bool` | Whether the planner explicitly emitted a finish action. |
+
+### `ReActStep` Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `step` | `int` | 1-based step number. |
+| `thought` | `str` | Short planner rationale. |
+| `action` | `str` | Either `"search"` or `"finish"`. |
+| `query` | `str \| None` | Search query used by a search action. |
+| `answer` | `str \| None` | Answer returned by a finish action. |
+| `observation` | `str` | Retrieved context returned to the planner. |
+| `retrieved_passages` | `list[str]` | Passages retrieved by the search action. |
+| `retrieved_relations` | `list[str]` | Relations retrieved by the search action. |
 
 ---
 

--- a/src/vector_graph_rag/__init__.py
+++ b/src/vector_graph_rag/__init__.py
@@ -12,8 +12,18 @@ from vector_graph_rag.graph.knowledge_graph import SubGraph
 from vector_graph_rag.graph.retriever import GraphRetriever
 from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 from vector_graph_rag.llm.extractor import TripletExtractor
+from vector_graph_rag.llm.react import ReActPlanner
 from vector_graph_rag.llm.reranker import LLMReranker
-from vector_graph_rag.models import Document, Entity, Passage, Relation, Triplet
+from vector_graph_rag.models import (
+    Document,
+    Entity,
+    Passage,
+    ReActAction,
+    ReActResult,
+    ReActStep,
+    Relation,
+    Triplet,
+)
 from vector_graph_rag.rag import VectorGraphRAG, create_rag
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
@@ -35,6 +45,10 @@ __all__ = [
     "SubGraph",
     "Graph",
     "LLMReranker",
+    "ReActPlanner",
+    "ReActAction",
+    "ReActStep",
+    "ReActResult",
     "VectorGraphRAG",
     "create_rag",
     "LLMCache",

--- a/src/vector_graph_rag/llm/react.py
+++ b/src/vector_graph_rag/llm/react.py
@@ -1,0 +1,204 @@
+"""
+ReAct planner for iterative retrieval.
+"""
+
+import json
+from typing import List, Optional
+
+from openai import OpenAI
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from vector_graph_rag.config import Settings, get_settings
+from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
+from vector_graph_rag.models import ReActAction, ReActStep
+
+REACT_SYSTEM_PROMPT = """You control a retrieval loop for answering questions.
+
+At each step, choose one JSON action:
+
+1. Search for more context:
+{"thought": "brief reason", "action": "search", "query": "focused search query"}
+
+2. Finish when the observations are enough:
+{"thought": "brief reason", "action": "finish", "answer": "final answer"}
+
+Rules:
+- Return only one JSON object.
+- Use "search" when more evidence is needed.
+- Use "finish" only when the observations contain enough evidence.
+- Keep "thought" brief and do not include hidden reasoning.
+"""
+
+REACT_USER_PROMPT = """Question:
+{question}
+
+Previous steps:
+{history}
+
+Current step: {step_number} of {max_steps}
+
+Choose the next action."""
+
+
+class ReActPlanner:
+    """
+    LLM planner for a basic ReAct search loop.
+
+    The planner emits either a search query or a final answer. Retrieval and
+    answer fallback are handled by VectorGraphRAG.
+    """
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        model: Optional[str] = None,
+        use_cache: Optional[bool] = None,
+        cache: Optional[LLMCache] = None,
+    ) -> None:
+        """
+        Initialize the planner.
+
+        Args:
+            settings: Configuration settings.
+            model: Override LLM model from settings.
+            use_cache: Whether to use LLM response caching.
+            cache: Custom cache instance.
+        """
+        self.settings = settings or get_settings()
+        self.settings.validate_settings()
+
+        self.model = model or self.settings.llm_model
+        self.client = OpenAI(
+            api_key=self.settings.openai_api_key,
+            base_url=self.settings.openai_base_url,
+        )
+        self.use_cache = use_cache if use_cache is not None else self.settings.use_llm_cache
+        self.cache = cache or get_llm_cache() if self.use_cache else None
+
+    @staticmethod
+    def _format_history(steps: List[ReActStep]) -> str:
+        """Format previous ReAct steps for the planner prompt."""
+        if not steps:
+            return "None"
+
+        sections = []
+        for step in steps:
+            lines = [
+                f"Step {step.step}",
+                f"Thought: {step.thought or ''}",
+                f"Action: {step.action}",
+            ]
+            if step.query:
+                lines.append(f"Query: {step.query}")
+            if step.observation:
+                lines.append(f"Observation: {step.observation}")
+            if step.answer:
+                lines.append(f"Answer: {step.answer}")
+            sections.append("\n".join(lines))
+        return "\n\n".join(sections)
+
+    def _build_prompt(
+        self,
+        question: str,
+        steps: List[ReActStep],
+        step_number: int,
+        max_steps: int,
+    ) -> str:
+        """Build the user prompt."""
+        return REACT_USER_PROMPT.format(
+            question=question,
+            history=self._format_history(steps),
+            step_number=step_number,
+            max_steps=max_steps,
+        )
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+    )
+    def _call_llm(self, prompt: str) -> str:
+        """Call the LLM with retry and optional cache."""
+        cache_key = f"{REACT_SYSTEM_PROMPT}\n\n{prompt}"
+        if self.cache:
+            cached = self.cache.get(self.model, cache_key, temperature=0)
+            if cached is not None:
+                return cached
+
+        messages = [
+            {"role": "system", "content": REACT_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ]
+        api_kwargs = {
+            "model": self.model,
+            "messages": messages,
+            "response_format": {"type": "json_object"},
+        }
+        if not self.model.startswith("gpt-5"):
+            api_kwargs["temperature"] = 0
+
+        response = self.client.chat.completions.create(**api_kwargs)
+        result = response.choices[0].message.content or "{}"
+
+        if self.cache:
+            self.cache.set(self.model, cache_key, result, temperature=0)
+
+        return result
+
+    @staticmethod
+    def _parse_response(response: str, question: str) -> ReActAction:
+        """Parse an LLM response into a planner action."""
+        try:
+            data = json.loads(response)
+        except json.JSONDecodeError:
+            return ReActAction(
+                thought="Fallback to search because the planner returned invalid JSON.",
+                action="search",
+                query=question,
+            )
+
+        action = str(data.get("action", "")).strip().lower()
+        thought = str(data.get("thought", "")).strip()
+
+        if action == "finish":
+            answer = str(data.get("answer", "")).strip()
+            if answer:
+                return ReActAction(
+                    thought=thought,
+                    action="finish",
+                    answer=answer,
+                )
+
+        query = str(data.get("query", "")).strip() or question
+        return ReActAction(
+            thought=thought,
+            action="search",
+            query=query,
+        )
+
+    def plan(
+        self,
+        question: str,
+        steps: List[ReActStep],
+        step_number: int,
+        max_steps: int,
+    ) -> ReActAction:
+        """
+        Plan the next ReAct action.
+
+        Args:
+            question: Original user question.
+            steps: Previous ReAct steps.
+            step_number: 1-based current step number.
+            max_steps: Maximum loop steps.
+
+        Returns:
+            Parsed planner action.
+        """
+        prompt = self._build_prompt(
+            question=question,
+            steps=steps,
+            step_number=step_number,
+            max_steps=max_steps,
+        )
+        response = self._call_llm(prompt)
+        return self._parse_response(response, question)

--- a/src/vector_graph_rag/models.py
+++ b/src/vector_graph_rag/models.py
@@ -15,6 +15,9 @@ __all__ = [
     "Relation",
     "Passage",
     "QueryResult",
+    "ReActAction",
+    "ReActStep",
+    "ReActResult",
     "ExtractionResult",
     "EvictionResult",
 ]
@@ -159,6 +162,69 @@ class EvictionResult(BaseModel):
     occurred: bool = Field(default=False, description="Whether eviction occurred")
     before_count: int = Field(default=0, description="Relations before eviction")
     after_count: int = Field(default=0, description="Relations after eviction")
+
+
+class ReActAction(BaseModel):
+    """
+    Planner action for one ReAct loop step.
+
+    Attributes:
+        thought: Short rationale for the selected action.
+        action: Either "search" or "finish".
+        query: Search query when action is "search".
+        answer: Final answer when action is "finish".
+    """
+
+    thought: str = Field(default="", description="Short rationale for the action")
+    action: str = Field(..., description='Planner action: "search" or "finish"')
+    query: Optional[str] = Field(default=None, description="Search query for search actions")
+    answer: Optional[str] = Field(default=None, description="Final answer for finish actions")
+
+
+class ReActStep(BaseModel):
+    """
+    Trace entry for one ReAct loop step.
+
+    Attributes:
+        step: 1-based loop step number.
+        thought: Short rationale emitted by the planner.
+        action: Action selected by the planner.
+        query: Search query used for search actions.
+        answer: Final answer emitted by a finish action.
+        observation: Text observation returned to the planner.
+        retrieved_passages: Passages retrieved by a search action.
+        retrieved_relations: Relations retrieved by a search action.
+    """
+
+    step: int = Field(..., description="1-based step number")
+    thought: str = Field(default="", description="Short planner rationale")
+    action: str = Field(..., description='Planner action: "search" or "finish"')
+    query: Optional[str] = Field(default=None, description="Search query used by this step")
+    answer: Optional[str] = Field(default=None, description="Answer returned by finish action")
+    observation: str = Field(default="", description="Observation returned to the planner")
+    retrieved_passages: List[str] = Field(default_factory=list)
+    retrieved_relations: List[str] = Field(default_factory=list)
+
+
+class ReActResult(BaseModel):
+    """
+    Result of a ReAct query loop.
+
+    Attributes:
+        query: The original question.
+        answer: Final answer from the planner or fallback answer generation.
+        steps: ReAct trace entries.
+        passages: Unique passages observed across search steps.
+        relations: Unique relations observed across search steps.
+        finished: Whether the planner explicitly emitted a finish action.
+    """
+
+    query: str = Field(..., description="Original query")
+    answer: str = Field(..., description="Final answer")
+    steps: List[ReActStep] = Field(default_factory=list, description="ReAct loop trace")
+    passages: List[str] = Field(default_factory=list, description="Observed passages")
+    relations: List[str] = Field(default_factory=list, description="Observed relations")
+    finished: bool = Field(default=False, description="Whether the planner finished explicitly")
 
 
 class QueryResult(BaseModel):

--- a/src/vector_graph_rag/rag.py
+++ b/src/vector_graph_rag/rag.py
@@ -13,6 +13,7 @@ from vector_graph_rag.graph.builder import GraphBuilder
 from vector_graph_rag.graph.knowledge_graph import SubGraph
 from vector_graph_rag.graph.retriever import GraphRetriever
 from vector_graph_rag.llm.extractor import TripletExtractor
+from vector_graph_rag.llm.react import ReActPlanner
 from vector_graph_rag.llm.reranker import AnswerGenerator, LLMReranker
 from vector_graph_rag.models import (
     Document,
@@ -20,6 +21,8 @@ from vector_graph_rag.models import (
     EvictionResult,
     ExtractionResult,
     QueryResult,
+    ReActResult,
+    ReActStep,
     Relation,
     RerankResult,
     RetrievalDetail,
@@ -159,6 +162,7 @@ class VectorGraphRAG:
         self._triplet_extractor = TripletExtractor(settings=self.settings)
         self._reranker = LLMReranker(settings=self.settings)
         self._answer_generator = AnswerGenerator(settings=self.settings)
+        self._react_planner = ReActPlanner(settings=self.settings)
 
         # Retriever is initialized after documents are added
         self._retriever: Optional[GraphRetriever] = None
@@ -193,6 +197,39 @@ class VectorGraphRAG:
             List of passage texts.
         """
         return subgraph.passage_texts
+
+    @staticmethod
+    def _append_unique(values: List[str], additions: List[str]) -> None:
+        """Append unique values in-place while preserving order."""
+        seen = set(values)
+        for value in additions:
+            if value not in seen:
+                seen.add(value)
+                values.append(value)
+
+    @staticmethod
+    def _format_react_observation(
+        passages: List[str],
+        relations: List[str],
+        max_items: int = 5,
+    ) -> str:
+        """Format retrieved context as a compact ReAct observation."""
+        lines: List[str] = []
+        if passages:
+            lines.append("Passages:")
+            for index, passage in enumerate(passages[:max_items], start=1):
+                lines.append(f"{index}. {passage}")
+        else:
+            lines.append("Passages: none")
+
+        if relations:
+            lines.append("Relations:")
+            for index, relation in enumerate(relations[:max_items], start=1):
+                lines.append(f"{index}. {relation}")
+        else:
+            lines.append("Relations: none")
+
+        return "\n".join(lines)
 
     @staticmethod
     def _get_user_passage_metadata(doc: Document) -> Dict[str, Any]:
@@ -1388,6 +1425,101 @@ class VectorGraphRAG:
             retrieved_relations=[],
             expanded_relations=[],
             reranked_relations=[],
+        )
+
+    def query_react(
+        self,
+        question: str,
+        max_steps: int = 3,
+        use_reranking: bool = True,
+        top_k: Optional[int] = None,
+        filter: Optional[str] = None,
+    ) -> ReActResult:
+        """
+        Query with a basic ReAct loop over Graph RAG retrieval.
+
+        The planner can search multiple times before returning a final answer.
+        Each search action uses the existing Graph RAG retrieval path. If the
+        planner does not finish within max_steps, an answer is generated from
+        the passages observed across search steps.
+
+        Args:
+            question: The question to answer.
+            max_steps: Maximum planner steps.
+            use_reranking: Whether each search uses LLM reranking.
+            top_k: Number of passages to retrieve per search step.
+            filter: Optional Milvus filter expression for passage metadata.
+
+        Returns:
+            ReActResult with final answer and step trace.
+        """
+        if max_steps < 1:
+            raise ValueError("max_steps must be >= 1.")
+
+        steps: List[ReActStep] = []
+        observed_passages: List[str] = []
+        observed_relations: List[str] = []
+
+        for step_number in range(1, max_steps + 1):
+            action = self._react_planner.plan(
+                question=question,
+                steps=steps,
+                step_number=step_number,
+                max_steps=max_steps,
+            )
+
+            if action.action == "finish":
+                answer = action.answer or ""
+                steps.append(
+                    ReActStep(
+                        step=step_number,
+                        thought=action.thought,
+                        action="finish",
+                        answer=answer,
+                    )
+                )
+                return ReActResult(
+                    query=question,
+                    answer=answer,
+                    steps=steps,
+                    passages=observed_passages,
+                    relations=observed_relations,
+                    finished=True,
+                )
+
+            search_query = action.query or question
+            retrieval_result = self.retrieve(
+                search_query,
+                use_reranking=use_reranking,
+                top_k=top_k,
+                filter=filter,
+            )
+            passages = retrieval_result.passages or retrieval_result.retrieved_passages
+            relations = retrieval_result.reranked_relations or retrieval_result.retrieved_relations
+            self._append_unique(observed_passages, passages)
+            self._append_unique(observed_relations, relations)
+            observation = self._format_react_observation(passages, relations)
+
+            steps.append(
+                ReActStep(
+                    step=step_number,
+                    thought=action.thought,
+                    action="search",
+                    query=search_query,
+                    observation=observation,
+                    retrieved_passages=passages,
+                    retrieved_relations=relations,
+                )
+            )
+
+        answer = self._answer_generator.generate(question, observed_passages)
+        return ReActResult(
+            query=question,
+            answer=answer,
+            steps=steps,
+            passages=observed_passages,
+            relations=observed_relations,
+            finished=False,
         )
 
     def retrieve(

--- a/tests/test_rag_react.py
+++ b/tests/test_rag_react.py
@@ -1,0 +1,471 @@
+"""Tests for ReAct query loops in VectorGraphRAG."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vector_graph_rag.config import Settings
+from vector_graph_rag.graph.retriever import GraphRetriever
+from vector_graph_rag.llm.react import ReActPlanner
+from vector_graph_rag.models import Document, ReActAction
+from vector_graph_rag.rag import VectorGraphRAG
+
+
+class FakeEmbeddingModel:
+    """Small deterministic embedding model for Milvus Lite tests."""
+
+    dimension = 4
+
+    def embed(self, text: str, text_type: str = "query") -> list[float]:
+        text = text.lower()
+        if "alpha" in text or "blue" in text:
+            return [1.0, 0.0, 0.0, 0.0]
+        if "beta" in text or "red" in text:
+            return [0.0, 1.0, 0.0, 0.0]
+        return [0.5, 0.5, 0.0, 0.0]
+
+    def embed_batch(
+        self,
+        texts: list[str],
+        batch_size: int | None = None,
+        show_progress: bool = False,
+        text_type: str = "query",
+    ) -> list[list[float]]:
+        return [self.embed(text, text_type=text_type) for text in texts]
+
+
+class FakeEntityExtractor:
+    """Deterministic entity extractor for query-time graph retrieval."""
+
+    def extract(self, question: str) -> list[str]:
+        if "beta" in question.lower():
+            return ["beta"]
+        return ["alpha"]
+
+
+def create_test_rag(milvus_uri: str, collection_prefix: str) -> VectorGraphRAG:
+    """Create a VectorGraphRAG instance with fake embeddings and no LLM calls."""
+    settings = Settings(
+        milvus_uri=milvus_uri,
+        openai_api_key="test-api-key",
+        embedding_provider="openai",
+        collection_prefix=collection_prefix,
+        final_top_k=3,
+    )
+    fake_embedding = FakeEmbeddingModel()
+
+    with patch("vector_graph_rag.rag.EmbeddingModel", return_value=fake_embedding):
+        rag = VectorGraphRAG(settings=settings)
+
+    rag._answer_generator.generate = MagicMock(
+        side_effect=lambda question, passages: "\n".join(passages)
+    )
+    return rag
+
+
+def create_live_llm_test_rag(milvus_uri: str, collection_prefix: str) -> VectorGraphRAG:
+    """Create a test RAG with fake embeddings and live LLM components."""
+    settings = Settings(
+        milvus_uri=milvus_uri,
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        llm_model=os.getenv("VGRAG_LLM_MODEL", "gpt-4o-mini"),
+        embedding_provider="openai",
+        collection_prefix=collection_prefix,
+        final_top_k=2,
+        use_llm_cache=False,
+    )
+    fake_embedding = FakeEmbeddingModel()
+
+    with patch("vector_graph_rag.rag.EmbeddingModel", return_value=fake_embedding):
+        rag = VectorGraphRAG(settings=settings)
+
+    return rag
+
+
+def with_temp_rag(collection_prefix: str):
+    """Create a temporary Milvus Lite backed RAG instance."""
+    temp_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_file.close()
+    rag = create_test_rag(temp_file.name, collection_prefix)
+    return rag, temp_file.name
+
+
+def remove_temp_milvus_file(milvus_uri: str) -> None:
+    """Remove a temporary Milvus Lite file if it exists."""
+    if os.path.exists(milvus_uri):
+        os.unlink(milvus_uri)
+
+
+def add_test_documents(rag: VectorGraphRAG) -> None:
+    """Index small pre-extracted documents for ReAct tests."""
+    rag.rebuild_documents(
+        [
+            Document(
+                page_content="Alpha owns the blue database.",
+                metadata={"triplets": [["Alpha", "owns", "blue database"]]},
+                id="doc_alpha",
+            ),
+            Document(
+                page_content="Beta owns the red database.",
+                metadata={"triplets": [["Beta", "owns", "red database"]]},
+                id="doc_beta",
+            ),
+        ],
+        extract_triplets=False,
+        show_progress=False,
+    )
+    rag._retriever = GraphRetriever(
+        store=rag._store,
+        graph_builder=rag._graph_builder,
+        settings=rag.settings,
+        embedding_model=rag._embedding_model,
+        entity_extractor=FakeEntityExtractor(),
+    )
+
+
+def add_tenant_documents(rag: VectorGraphRAG) -> None:
+    """Index small pre-extracted documents with tenant metadata."""
+    rag.rebuild_documents(
+        [
+            Document(
+                page_content="Alpha owns the blue database.",
+                metadata={
+                    "triplets": [["Alpha", "owns", "blue database"]],
+                    "tenant_id": "team_a",
+                },
+                id="doc_alpha",
+            ),
+            Document(
+                page_content="Beta owns the red database.",
+                metadata={
+                    "triplets": [["Beta", "owns", "red database"]],
+                    "tenant_id": "team_b",
+                },
+                id="doc_beta",
+            ),
+        ],
+        extract_triplets=False,
+        show_progress=False,
+    )
+    rag._retriever = GraphRetriever(
+        store=rag._store,
+        graph_builder=rag._graph_builder,
+        settings=rag.settings,
+        embedding_model=rag._embedding_model,
+        entity_extractor=FakeEntityExtractor(),
+    )
+
+
+def test_query_react_searches_then_finishes():
+    """Run one retrieval step and then finish with the planner answer."""
+    rag, milvus_uri = with_temp_rag("react_search_finish")
+
+    try:
+        add_test_documents(rag)
+        rag._react_planner.plan = MagicMock(
+            side_effect=[
+                ReActAction(
+                    thought="Need Alpha evidence.",
+                    action="search",
+                    query="What database does Alpha own?",
+                ),
+                ReActAction(
+                    thought="The evidence is enough.",
+                    action="finish",
+                    answer="Alpha owns the blue database.",
+                ),
+            ]
+        )
+
+        result = rag.query_react(
+            "What database does Alpha own?",
+            max_steps=3,
+            use_reranking=False,
+        )
+
+        assert result.answer == "Alpha owns the blue database."
+        assert result.finished is True
+        assert [step.action for step in result.steps] == ["search", "finish"]
+        assert "Alpha owns the blue database." in result.steps[0].retrieved_passages
+        assert "Passages:" in result.steps[0].observation
+        assert "Alpha owns the blue database." in result.passages
+        rag._answer_generator.generate.assert_not_called()
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_can_finish_without_searching():
+    """Allow the planner to finish immediately without running retrieval."""
+    rag, milvus_uri = with_temp_rag("react_finish_immediately")
+
+    try:
+        rag._react_planner.plan = MagicMock(
+            return_value=ReActAction(
+                thought="No retrieval needed.",
+                action="finish",
+                answer="Direct answer.",
+            )
+        )
+
+        result = rag.query_react("Return a direct answer.", max_steps=3)
+
+        assert result.answer == "Direct answer."
+        assert result.finished is True
+        assert len(result.steps) == 1
+        assert result.steps[0].action == "finish"
+        assert result.passages == []
+        rag._answer_generator.generate.assert_not_called()
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_runs_multiple_searches_and_deduplicates_observations():
+    """Run multiple search actions and keep unique observed passages."""
+    rag, milvus_uri = with_temp_rag("react_multi_search")
+
+    try:
+        add_test_documents(rag)
+        rag._react_planner.plan = MagicMock(
+            side_effect=[
+                ReActAction(thought="Search Alpha.", action="search", query="Alpha database"),
+                ReActAction(thought="Search Beta.", action="search", query="Beta database"),
+                ReActAction(
+                    thought="Enough evidence.",
+                    action="finish",
+                    answer="Alpha owns blue and Beta owns red.",
+                ),
+            ]
+        )
+
+        result = rag.query_react(
+            "What databases do Alpha and Beta own?",
+            max_steps=3,
+            use_reranking=False,
+        )
+
+        assert result.finished is True
+        assert [step.action for step in result.steps] == ["search", "search", "finish"]
+        assert "Alpha owns the blue database." in result.passages
+        assert "Beta owns the red database." in result.passages
+        assert len(result.passages) == len(set(result.passages))
+        assert (
+            rag._react_planner.plan.call_args_list[1].kwargs["steps"][0].query == "Alpha database"
+        )
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_applies_metadata_filter_to_search_steps():
+    """Apply the metadata filter to each ReAct search action."""
+    rag, milvus_uri = with_temp_rag("react_filter")
+
+    try:
+        add_tenant_documents(rag)
+        rag._react_planner.plan = MagicMock(
+            side_effect=[
+                ReActAction(
+                    thought="Search within team A.",
+                    action="search",
+                    query="What database does Alpha own?",
+                ),
+                ReActAction(
+                    thought="Enough evidence.",
+                    action="finish",
+                    answer="Alpha owns the blue database.",
+                ),
+            ]
+        )
+
+        result = rag.query_react(
+            "What database does Alpha own?",
+            max_steps=2,
+            use_reranking=False,
+            filter='tenant_id == "team_a"',
+        )
+
+        assert result.finished is True
+        assert result.passages == ["Alpha owns the blue database."]
+        assert "red database" not in result.steps[0].observation
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_passes_retrieval_options_to_each_search_step():
+    """Forward per-call retrieval options from query_react to retrieve."""
+    rag, milvus_uri = with_temp_rag("react_retrieval_options")
+
+    try:
+        rag._react_planner.plan = MagicMock(
+            side_effect=[
+                ReActAction(thought="Search.", action="search", query="focused query"),
+                ReActAction(thought="Done.", action="finish", answer="done"),
+            ]
+        )
+        rag.retrieve = MagicMock(
+            return_value=MagicMock(
+                passages=["Retrieved passage."],
+                retrieved_passages=["Retrieved passage."],
+                reranked_relations=["Retrieved relation."],
+                retrieved_relations=["Retrieved relation."],
+            )
+        )
+
+        result = rag.query_react(
+            "Original question?",
+            max_steps=2,
+            use_reranking=False,
+            top_k=1,
+            filter='tenant_id == "team_a"',
+        )
+
+        assert result.answer == "done"
+        rag.retrieve.assert_called_once_with(
+            "focused query",
+            use_reranking=False,
+            top_k=1,
+            filter='tenant_id == "team_a"',
+        )
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_falls_back_to_answer_generation_after_max_steps():
+    """Generate a final answer from observed passages when the planner keeps searching."""
+    rag, milvus_uri = with_temp_rag("react_fallback_answer")
+
+    try:
+        add_test_documents(rag)
+        rag._react_planner.plan = MagicMock(
+            return_value=ReActAction(
+                thought="Keep searching.",
+                action="search",
+                query="What database does Alpha own?",
+            )
+        )
+        rag._answer_generator.generate = MagicMock(return_value="Fallback answer.")
+
+        result = rag.query_react(
+            "What database does Alpha own?",
+            max_steps=2,
+            use_reranking=False,
+        )
+
+        assert result.answer == "Fallback answer."
+        assert result.finished is False
+        assert len(result.steps) == 2
+        assert "Alpha owns the blue database." in result.passages
+        assert len(result.passages) == len(set(result.passages))
+        rag._answer_generator.generate.assert_called_once_with(
+            "What database does Alpha own?",
+            result.passages,
+        )
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_query_react_validates_max_steps():
+    """Reject invalid max_steps values."""
+    rag, milvus_uri = with_temp_rag("react_validate_max_steps")
+
+    try:
+        with pytest.raises(ValueError, match="max_steps"):
+            rag.query_react("What database does Alpha own?", max_steps=0)
+    finally:
+        remove_temp_milvus_file(milvus_uri)
+
+
+def test_react_planner_parses_search_finish_and_invalid_json():
+    """Parse planner JSON responses and fall back to a search on invalid JSON."""
+    settings = Settings(
+        milvus_uri="./react_parse_test.db",
+        openai_api_key="test-api-key",
+        embedding_provider="openai",
+        use_llm_cache=False,
+    )
+    planner = ReActPlanner(settings=settings)
+
+    search = planner._parse_response(
+        '{"thought": "Need evidence.", "action": "search", "query": "alpha database"}',
+        question="original question",
+    )
+    assert search.action == "search"
+    assert search.query == "alpha database"
+
+    finish = planner._parse_response(
+        '{"thought": "Enough.", "action": "finish", "answer": "Alpha owns blue."}',
+        question="original question",
+    )
+    assert finish.action == "finish"
+    assert finish.answer == "Alpha owns blue."
+
+    fallback = planner._parse_response("not json", question="original question")
+    assert fallback.action == "search"
+    assert fallback.query == "original question"
+
+    missing_answer = planner._parse_response(
+        '{"thought": "No answer.", "action": "finish"}',
+        question="original question",
+    )
+    assert missing_answer.action == "search"
+    assert missing_answer.query == "original question"
+
+
+def test_react_planner_formats_history_for_prompt():
+    """Include previous thoughts, actions, queries, and observations in planner prompts."""
+    history = [
+        ReActAction(
+            thought="Need Alpha evidence.",
+            action="search",
+            query="Alpha database",
+        )
+    ]
+    step = history[0]
+    formatted = ReActPlanner._format_history(
+        [
+            MagicMock(
+                step=1,
+                thought=step.thought,
+                action=step.action,
+                query=step.query,
+                observation="Passages:\n1. Alpha owns the blue database.",
+                answer=None,
+            )
+        ]
+    )
+
+    assert "Step 1" in formatted
+    assert "Need Alpha evidence." in formatted
+    assert "Alpha database" in formatted
+    assert "Alpha owns the blue database." in formatted
+
+
+@pytest.mark.skipif(
+    os.getenv("RUN_LIVE_OPENAI_TESTS") != "1" or not os.getenv("OPENAI_API_KEY"),
+    reason="Set RUN_LIVE_OPENAI_TESTS=1 and OPENAI_API_KEY to run live OpenAI ReAct tests.",
+)
+def test_query_react_with_live_openai_planner_answers_from_retrieved_context():
+    """Smoke test the real OpenAI planner against an end-to-end ReAct query."""
+    temp_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_file.close()
+    milvus_uri = temp_file.name
+
+    try:
+        rag = create_live_llm_test_rag(milvus_uri, "react_live_openai")
+        add_tenant_documents(rag)
+
+        result = rag.query_react(
+            "Search first, then answer: what color database does Alpha own?",
+            max_steps=3,
+            use_reranking=False,
+            top_k=1,
+            filter='tenant_id == "team_a"',
+        )
+
+        assert any(step.action == "search" for step in result.steps)
+        assert "Alpha owns the blue database." in result.passages
+        assert "blue" in result.answer.lower()
+        assert "red" not in result.answer.lower()
+    finally:
+        remove_temp_milvus_file(milvus_uri)


### PR DESCRIPTION
## Summary
- add a lightweight ReAct planner for iterative search and finish actions
- expose VectorGraphRAG.query_react() with step traces and fallback answer generation
- add ReAct result models and package exports
- document the Python API and README usage
- expand ReAct coverage across control flow, metadata filters, multi-search, planner parsing, prompt history, and optional live OpenAI smoke testing

## Tests
- uv run ruff check tests/test_rag_react.py src/vector_graph_rag/llm/react.py src/vector_graph_rag/rag.py src/vector_graph_rag/models.py src/vector_graph_rag/__init__.py
- uv run ruff format --check tests/test_rag_react.py src/vector_graph_rag/llm/react.py src/vector_graph_rag/rag.py src/vector_graph_rag/models.py src/vector_graph_rag/__init__.py
- uv run pytest tests/test_rag_react.py -q (9 passed, 1 skipped)
- RUN_LIVE_OPENAI_TESTS=1 uv run pytest tests/test_rag_react.py::test_query_react_with_live_openai_planner_answers_from_retrieved_context -q -s (1 passed)
- uv run pytest tests/test_rag_react.py tests/test_rag_metadata_filter.py tests/test_rag_incremental.py -q (23 passed, 1 skipped)
- uv run --extra docs mkdocs build --strict
- uv run pytest -q (101 passed, 1 skipped before Milvus Lite cleanup hang)

Live OpenAI smoke output showed the real planner searched twice, then finished with answer: Alpha owns the blue database.