### PR TITLE
Document source-level incremental updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ argument. The method replaces only that source's chunks and graph references.
 Source-level writes are not transactionally atomic, but the same upsert/delete
 operation can be retried after an interruption to converge the source back to a
 consistent state.
+See the [Incremental Updates guide](docs/incremental-updates.md) for parser
+integration, source key design, and retry recommendations.
 
 ```python
 from langchain_core.documents import Document
@@ -121,7 +123,7 @@ rag.upsert_documents_by_source(
         Document(
             page_content="Einstein developed relativity at Princeton.",
             metadata={
-                "source": "sharepoint:file-123",
+                "source": "file:file-123",
                 "triplets": [
                     ["Einstein", "developed", "relativity"],
                     ["Einstein", "worked at", "Princeton"],
@@ -132,7 +134,7 @@ rag.upsert_documents_by_source(
     extract_triplets=False,
 )
 
-rag.delete_documents_by_source("sharepoint:file-123")
+rag.delete_documents_by_source("file:file-123")
 ```
 
 > **Migration note:** v0.1.5 exposed `upsert_documents(document_id=...)` and

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,7 +61,7 @@ Frequently asked questions about Vector Graph RAG — covering when to use it, c
     rag.delete_documents_by_source("file-123")
     ```
 
-    Incremental updates replace only the chunks and graph references for that source value. They are not transactionally atomic, so avoid interrupting or concurrently mutating the same collection prefix during an update.
+    Incremental updates replace only the chunks and graph references for that source value. They are not transactionally atomic. If a write is interrupted, rerun the same source operation to converge the source back to a consistent state. See [Incremental Updates](incremental-updates.md) for the full parser, CUD, and retry pattern.
 
 ??? note "Can I use local/open-source LLMs?"
     Yes. Vector Graph RAG uses the OpenAI-compatible API format, so any LLM that exposes an OpenAI-compatible endpoint will work. This includes local models served via [Ollama](https://ollama.com/), [vLLM](https://github.com/vllm-project/vllm), [LM Studio](https://lmstudio.ai/), or any other OpenAI-compatible server. You can configure the base URL and model name when initializing the RAG instance. Keep in mind that triplet extraction and reranking quality depend heavily on the LLM's capability — weaker models may produce incomplete or inaccurate triplets, which directly affects retrieval quality. For best results, use a model with strong instruction-following and reasoning abilities.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,6 +186,11 @@ rag.rebuild_documents(result.documents, extract_triplets=True)
 
 Use `upsert_documents_by_source()` when a source file, page, or message is created or modified. In Vector Graph RAG, a `Document` is a passage/chunk, and `metadata["source"]` identifies the source object whose chunks should be replaced.
 
+For parser and loader workflows, attach the same stable source value to every
+chunk produced from one file, page, or message. See
+[Incremental Updates](incremental-updates.md) for the full source-level CUD and
+retry pattern.
+
 ```python
 from langchain_core.documents import Document
 
@@ -194,7 +199,7 @@ rag.upsert_documents_by_source(
         Document(
             page_content="Einstein developed relativity at Princeton.",
             metadata={
-                "source": "sharepoint:file-123",
+                "source": "file:file-123",
                 "triplets": [
                     ["Einstein", "developed", "relativity"],
                     ["Einstein", "worked at", "Princeton"],
@@ -205,7 +210,7 @@ rag.upsert_documents_by_source(
     extract_triplets=False,
 )
 
-rag.delete_documents_by_source("sharepoint:file-123")
+rag.delete_documents_by_source("file:file-123")
 ```
 
 !!! warning "v0.2.0 migration"

--- a/docs/incremental-updates.md
+++ b/docs/incremental-updates.md
@@ -1,0 +1,245 @@
+# Incremental Updates
+
+Use source-level incremental updates when your upstream system can tell you
+which external object changed. A source can be a file, web page, email message,
+database row, or any other stable business object.
+
+In Vector Graph RAG, a LangChain `Document` represents one passage or chunk.
+The source object is tracked through metadata, not through `Document.id`.
+
+## Core Contract
+
+Each incremental update call must contain chunks from exactly one source.
+
+```python
+from langchain_core.documents import Document
+
+chunks = [
+    Document(
+        page_content="Q2 revenue increased in the enterprise segment.",
+        metadata={
+            "source": "file:file-123",
+            "page": 1,
+            "chunk_index": 0,
+        },
+    ),
+    Document(
+        page_content="Renewal rates improved after support response times dropped.",
+        metadata={
+            "source": "file:file-123",
+            "page": 2,
+            "chunk_index": 1,
+        },
+    ),
+]
+
+rag.upsert_documents_by_source(chunks)
+```
+
+The default grouping field is `metadata["source"]`. You can also pass the
+source explicitly:
+
+```python
+rag.upsert_documents_by_source(
+    documents=chunks,
+    source="file:file-123",
+)
+```
+
+Use a custom field when your application already has a different metadata name:
+
+```python
+rag.upsert_documents_by_source(
+    documents=chunks,
+    source="file-123",
+    source_field="file_id",
+)
+
+rag.delete_documents_by_source("file-123", source_field="file_id")
+```
+
+## Parser Or Loader Output
+
+Document parsing is intentionally outside the core incremental API. Use your
+existing loader or parser to produce text chunks, then attach the same stable
+source value to every chunk from the same external object.
+
+```python
+from langchain_core.documents import Document
+from vector_graph_rag import VectorGraphRAG
+
+
+def parse_file_to_chunks(path: str) -> list[str]:
+    """Return text chunks from your parser or document processing pipeline."""
+    return [
+        "The handbook describes the support escalation policy.",
+        "Escalated issues must include the customer impact and owner.",
+    ]
+
+
+def index_file(rag: VectorGraphRAG, path: str, file_id: str) -> None:
+    chunks = [
+        Document(
+            page_content=text,
+            metadata={
+                "source": f"file:{file_id}",
+                "chunk_index": index,
+                "parser": "internal",
+            },
+        )
+        for index, text in enumerate(parse_file_to_chunks(path))
+    ]
+
+    rag.upsert_documents_by_source(chunks, extract_triplets=True)
+```
+
+If your parser also extracts knowledge graph triplets, store them in each
+chunk's `metadata["triplets"]` and disable LLM triplet extraction:
+
+```python
+chunks = [
+    Document(
+        page_content="The handbook describes the support escalation policy.",
+        metadata={
+            "source": "file:file-123",
+            "triplets": [
+                ["handbook", "describes", "support escalation policy"],
+                ["escalated issues", "include", "customer impact"],
+            ],
+        },
+    )
+]
+
+rag.upsert_documents_by_source(chunks, extract_triplets=False)
+```
+
+## Create, Update, Delete
+
+Use the same upsert API for both create and update.
+
+```python
+# Create or replace one source.
+rag.upsert_documents_by_source(
+    documents=chunks,
+    source="file:file-123",
+)
+
+# Delete one source.
+rag.delete_documents_by_source("file:file-123")
+```
+
+When a source already exists, `upsert_documents_by_source()` removes the old
+chunks and graph references for that source, then inserts the new chunks. Other
+sources under the same collection prefix are preserved.
+
+For multi-source updates, call the API once per source:
+
+```python
+for source, chunks in changed_sources:
+    rag.upsert_documents_by_source(chunks, source=source)
+```
+
+## Retry Behavior
+
+Source-level updates perform a multi-step cascade across passages, relations,
+and entities. Milvus does not provide a transaction that spans those logical
+records, so these writes are not transactionally atomic. If the process is
+interrupted, queries may observe intermediate state until the update is retried.
+
+The source-level APIs are designed to be retryable. If an upsert or delete
+raises an exception, rerun the same operation for the same source.
+
+```python
+try:
+    rag.upsert_documents_by_source(
+        documents=chunks,
+        source="file:file-123",
+    )
+except Exception:
+    # Log the failed source in your application job state, then retry it.
+    rag.upsert_documents_by_source(
+        documents=chunks,
+        source="file:file-123",
+    )
+```
+
+For delete:
+
+```python
+try:
+    rag.delete_documents_by_source("file:file-123")
+except Exception:
+    rag.delete_documents_by_source("file:file-123")
+```
+
+A production ingestion job should track which source keys succeeded or failed.
+If a retry sees no matching passages during delete, the source may already have
+been removed by the previous attempt.
+
+## ID Guidance
+
+Use `source` for the external object identity. Use `Document.id` only when you
+need to control the passage ID.
+
+If `Document.id` is omitted, `upsert_documents_by_source()` generates stable
+passage IDs from the source value and chunk index. If you provide `Document.id`,
+make sure it is unique to that passage and does not belong to another source.
+
+Good source values are stable and globally meaningful in your application:
+
+```text
+file:file-123
+url:https://example.com/docs/pricing
+message:message-456
+record:account-789
+```
+
+Avoid using a chunk ID, page number, or transient parser output path as the
+source. Those values identify a passage or a local processing artifact, not the
+external object that should be replaced as a unit.
+
+## Metadata And Filtering
+
+Additional metadata is stored on passages and can be used for filtering.
+
+```python
+rag.upsert_documents_by_source(
+    documents=chunks,
+    source="file:file-123",
+    metadata={
+        "tenant_id": "tenant-a",
+        "workspace_id": "finance",
+    },
+)
+
+result = rag.query(
+    "What should escalated issues include?",
+    filter='tenant_id == "tenant-a" and workspace_id == "finance"',
+)
+```
+
+The source metadata is also stored on each passage, so you can filter by source
+when needed:
+
+```python
+result = rag.query(
+    "What should escalated issues include?",
+    filter='source == "file:file-123"',
+)
+```
+
+## Initial Bulk Load
+
+For a first-time corpus load, you can either use `rebuild_documents()` or call
+`upsert_documents_by_source()` once per source. Use `rebuild_documents()` when
+you intentionally want a full refresh of the collection prefix. Use
+`upsert_documents_by_source()` when you want the same ingestion path for initial
+load and later CUD events.
+
+```python
+for source, chunks in all_sources:
+    rag.upsert_documents_by_source(chunks, source=source)
+```
+
+Avoid the legacy `add_*` helpers for new ingestion code. They keep their old
+full-rebuild behavior and are planned for removal in v1.0.0.

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ print(result.answer)
 ```
 
 !!! note "Ingestion semantics"
-    The legacy `add_*` ingestion helpers rebuild the full knowledge base and are planned for removal in v1.0.0. Use `rebuild_texts()`, `rebuild_documents()`, or `rebuild_documents_with_triplets()` for full refreshes, and use `upsert_documents_by_source()` / `delete_documents_by_source()` when a source file, page, or message changes later.
+    The legacy `add_*` ingestion helpers rebuild the full knowledge base and are planned for removal in v1.0.0. Use `rebuild_texts()`, `rebuild_documents()`, or `rebuild_documents_with_triplets()` for full refreshes, and use `upsert_documents_by_source()` / `delete_documents_by_source()` when a source file, page, or message changes later. See [Incremental Updates](incremental-updates.md) for parser integration, source key design, and retry recommendations.
 
 !!! tip "Getting Started"
     See the [Getting Started](getting-started.md) guide for installation and configuration options.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -377,7 +377,7 @@ Optional `metadata` is stored on the passage and can be used by query filters.
 
 #### `upsert_documents_by_source`
 
-Incrementally create or replace all chunks that belong to one source. A source can be a file, page, message, SharePoint item, business record, or any other stable external object. In Vector Graph RAG, a LangChain `Document` is a passage/chunk; source ownership is represented by `metadata["source"]` by default.
+Incrementally create or replace all chunks that belong to one source. A source can be a file, page, message, database row, business record, or any other stable external object. In Vector Graph RAG, a LangChain `Document` is a passage/chunk; source ownership is represented by `metadata["source"]` by default.
 
 ```python
 def upsert_documents_by_source(
@@ -407,6 +407,9 @@ Source-level writes are not transactionally atomic. If an upsert fails during th
 
 The method accepts exactly one source per call. If `source` is not provided and the documents contain multiple `metadata[source_field]` values, it raises `ValueError`.
 
+For end-to-end parser and loader examples, see
+[Incremental Updates](incremental-updates.md).
+
 ```python
 from langchain_core.documents import Document
 
@@ -414,7 +417,7 @@ chunks = [
     Document(
         page_content="Alpha owns the blue database.",
         metadata={
-            "source": "sharepoint:file-123",
+            "source": "file:file-123",
             "triplets": [["Alpha", "owns", "blue database"]],
         },
     )
@@ -452,7 +455,7 @@ Shared entities and relations are preserved when other sources still reference t
 Source-level deletes are retryable. If a delete fails after partially cleaning graph records, rerun `delete_documents_by_source()` with the same `source` and `source_field` to finish the cascade.
 
 ```python
-deleted = rag.delete_documents_by_source("sharepoint:file-123")
+deleted = rag.delete_documents_by_source("file:file-123")
 ```
 
 !!! warning "v0.2.0 migration"

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -161,7 +161,7 @@ curl -X DELETE http://localhost:8000/graph/my_graph
 Indexes documents by rebuilding the selected graph. Optionally extracts knowledge graph triplets from the text using the configured LLM.
 
 !!! warning "Full rebuild"
-    This endpoint uses the Python full-rebuild ingestion path. Calling it replaces the current graph contents for the selected `graph_name`. Source-level incremental upsert/delete is currently available through the Python API via `upsert_documents_by_source()` and `delete_documents_by_source()`.
+    This endpoint uses the Python full-rebuild ingestion path. Calling it replaces the current graph contents for the selected `graph_name`. Source-level incremental upsert/delete is currently available through the Python API via `upsert_documents_by_source()` and `delete_documents_by_source()`. See [Incremental Updates](incremental-updates.md) for the source-level parser and retry workflow.
 
 **Query Parameters**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ extra_css:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Incremental Updates: incremental-updates.md
   - Architecture:
     - How It Works: how-it-works.md
     - Design Philosophy: design-philosophy.md


### PR DESCRIPTION
## Summary
- Add a dedicated Incremental Updates guide for source-level CUD workflows.
- Document parser/loader integration, stable source key design, custom source fields, metadata filtering, and retry behavior after interrupted writes.
- Link the guide from the main docs, README, Python API, REST API, Getting Started, and FAQ pages.

## Tests
- `uv run --extra docs mkdocs build --strict`
- `uv run pytest tests/test_rag_incremental.py -q`