### PR TITLE
Add OpenTelemetry observability hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ uv add "vector-graph-rag[all]"
 
 </details>
 
+<details>
+<summary><b>With OpenTelemetry tracing</b></summary>
+
+```bash
+pip install "vector-graph-rag[observability]"
+# or
+uv add "vector-graph-rag[observability]"
+```
+
+</details>
+
 ## 🚀 Quick Start
 
 ```python
@@ -145,6 +156,34 @@ rag.delete_documents_by_source("file:file-123")
 The legacy `add_*` ingestion helpers rebuild the full knowledge base and are planned
 for removal in v1.0.0. For explicit full refreshes, use `rebuild_texts()`,
 `rebuild_documents()`, or `rebuild_documents_with_triplets()`.
+
+</details>
+
+<details>
+<summary>📈 <b>OpenTelemetry tracing</b> — click to expand</summary>
+
+Vector Graph RAG can emit OpenTelemetry spans for ingestion, loaders,
+embeddings, Milvus operations, retrieval, and generation. Configure the
+OpenTelemetry SDK/exporter in your application, then attach request context
+around RAG calls:
+
+```python
+from vector_graph_rag import VectorGraphRAG, observability_context
+
+rag = VectorGraphRAG(collection_prefix="my_project")
+
+with observability_context(
+    request_id="req-123",
+    tenant_id="tenant-a",
+    graph_name="my_project",
+    source="file-123",
+):
+    rag.upsert_documents_by_source(chunks, source="file-123")
+```
+
+The built-in spans avoid document text, prompts, query text, generated answers,
+filters, and full URLs by default. See the
+[Observability guide](docs/observability.md) for setup details.
 
 </details>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,12 @@
     pip install "vector-graph-rag[all]"
     ```
 
+=== "With observability"
+
+    ```bash
+    pip install "vector-graph-rag[observability]"
+    ```
+
 !!! note "Prerequisites"
     - Python 3.9+
     - An OpenAI API key (set `OPENAI_API_KEY` environment variable)
@@ -233,6 +239,26 @@ rag.delete_documents_by_source("file:file-123")
 
 !!! note "Consistency model"
     Incremental updates perform a source-level cascade across passages, entities, and relations. They are not transactionally atomic, and queries may observe intermediate state if a write is interrupted. If an upsert or delete fails, rerun the same operation for the same source to converge the source back to a consistent state. Avoid concurrently mutating the same collection prefix during an update.
+
+## Observability
+
+Install `vector-graph-rag[observability]` to enable OpenTelemetry trace instrumentation. The library creates spans for ingestion, loading, embeddings, Milvus operations, retrieval, and generation, while your application configures the OpenTelemetry SDK and exporter.
+
+```python
+from vector_graph_rag import VectorGraphRAG, observability_context
+
+rag = VectorGraphRAG(collection_prefix="my_project")
+
+with observability_context(
+    request_id="req-123",
+    tenant_id="tenant-a",
+    graph_name="my_project",
+    source="file-123",
+):
+    rag.upsert_documents_by_source(chunks, source="file-123")
+```
+
+See [Observability](observability.md) for setup, span coverage, and data-safety notes.
 
 ## Querying
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,99 @@
+# Observability
+
+Vector Graph RAG can emit OpenTelemetry traces for ingestion, retrieval, LLM, embedding, loader, and Milvus operations. This is optional instrumentation: the library creates spans when OpenTelemetry is installed, but your application remains responsible for configuring the SDK and exporter.
+
+## Installation
+
+Install the observability extra:
+
+```bash
+pip install "vector-graph-rag[observability]"
+# or
+uv add "vector-graph-rag[observability]"
+```
+
+For local development or tests, install an OpenTelemetry SDK/exporter in the application environment. For example:
+
+```bash
+uv add opentelemetry-sdk
+```
+
+## Configure OpenTelemetry
+
+Configure OpenTelemetry once in your application before creating or using `VectorGraphRAG`:
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
+```
+
+You can replace `ConsoleSpanExporter` with any exporter or distribution supported by your deployment. For managed observability platforms, configure the platform's OpenTelemetry package in the host application; Vector Graph RAG does not add platform-specific dependencies.
+
+## Add Request Context
+
+Use `observability_context()` to attach safe request-level attributes to all spans created inside a call chain:
+
+```python
+from vector_graph_rag import VectorGraphRAG, observability_context
+
+rag = VectorGraphRAG(collection_prefix="finance")
+
+with observability_context(
+    request_id="req-123",
+    tenant_id="tenant-a",
+    graph_name="finance",
+    source="file-123",
+    attributes={
+        "app.import_job_id": "job-456",
+        "app.parser": "custom-parser",
+    },
+):
+    rag.upsert_documents_by_source(
+        chunks,
+        source="file-123",
+        extract_triplets=False,
+    )
+```
+
+The standard context fields are:
+
+| Field | Purpose |
+|---|---|
+| `request_id` | Correlate application requests with Vector Graph RAG spans. |
+| `tenant_id` | Identify the tenant or workspace for multi-tenant deployments. |
+| `graph_name` | Identify the knowledge base, graph, or collection prefix. |
+| `source` | Identify the external source being imported, updated, or deleted. |
+| `attributes` | Add application-specific low-sensitivity attributes. |
+
+Custom `attributes` should use a namespace such as `app.import_job_id` or `app.pipeline`. Attribute values are normalized to OpenTelemetry-compatible scalar or scalar-list values.
+
+## Span Coverage
+
+The built-in spans cover the main pipeline stages:
+
+| Area | Example spans |
+|---|---|
+| Ingestion | `vgrag.rebuild_documents`, `vgrag.upsert_documents_by_source`, `vgrag.delete_documents_by_source` |
+| Loading | `vgrag.import_sources`, `vgrag.import_source`, `vgrag.chunk_text`, `vgrag.convert_document`, `vgrag.fetch_url` |
+| Extraction | `vgrag.extract_triplets.batch`, `vgrag.extract_triplets`, `vgrag.extract_query_entities` |
+| Embeddings | `vgrag.embedding.batch`, `vgrag.embedding.embed` |
+| Storage | `vgrag.milvus.insert`, `vgrag.milvus.upsert`, `vgrag.milvus.search`, `vgrag.milvus.query`, `vgrag.milvus.delete` |
+| Retrieval | `vgrag.retrieve.graph`, `vgrag.retrieve.entities`, `vgrag.retrieve.relations`, `vgrag.subgraph.expand` |
+| Generation | `vgrag.rerank`, `vgrag.answer` |
+
+The packaged REST API also attaches request context from `x-request-id` or `x-correlation-id`, `x-tenant-id`, and the graph name when available.
+
+## Data Safety
+
+By default, Vector Graph RAG records operational metadata such as counts, booleans, model names, collection names, operation names, and safe context attributes. It does not record document text, prompt text, query text, generated answers, filters, or full URLs as span attributes.
+
+Use stable internal identifiers for `tenant_id`, `source`, and custom attributes when those values could expose sensitive information.
+
+## No-Op Behavior
+
+If OpenTelemetry is not installed, `observability_context()` still keeps local context for the active block and `start_span()` becomes a no-op. This keeps the core package lightweight and avoids requiring observability dependencies in small deployments.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -15,6 +15,8 @@ The Vector Graph RAG library exposes a small, focused surface area:
 | [`QueryResult`](#queryresult) | Structured output from queries |
 | [`ExtractionResult`](#extractionresult) | Structured output from document ingestion |
 | [`DocumentImporter`](#documentimporter) | Load and chunk files (PDF, DOCX, TXT, MD, HTML, URLs) |
+| [`observability_context()`](#observability_context) | Attach request, tenant, graph, and source context to OpenTelemetry spans |
+| [`start_span()`](#start_span) | Create custom spans that share the active Vector Graph RAG context |
 | [`create_rag()`](#create_rag) | Convenience factory for quick setup |
 
 ---
@@ -168,6 +170,69 @@ rag = VectorGraphRAG(
 ```
 
 Install optional provider dependencies as needed: `hf`, `google`, `voyage`, `jina`, `mistral`, `ollama`, `local`, or `onnx`.
+
+### Observability Helpers
+
+Install `vector-graph-rag[observability]` to emit OpenTelemetry spans. The library uses the OpenTelemetry API only; configure the SDK and exporter in your application.
+
+#### `observability_context`
+
+Attach low-sensitivity context attributes to all spans created inside the block.
+
+```python
+from vector_graph_rag import VectorGraphRAG, observability_context
+
+rag = VectorGraphRAG(collection_prefix="finance")
+
+with observability_context(
+    request_id="req-123",
+    tenant_id="tenant-a",
+    graph_name="finance",
+    source="file-123",
+    attributes={"app.import_job_id": "job-456"},
+):
+    rag.upsert_documents_by_source(chunks, source="file-123")
+```
+
+```python
+def observability_context(
+    request_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    source: Optional[str] = None,
+    attributes: Optional[Mapping[str, Any]] = None,
+) -> Iterator[None]
+```
+
+| Parameter | Description |
+|---|---|
+| `request_id` | Request or correlation ID from the host application. |
+| `tenant_id` | Tenant or workspace identifier. |
+| `graph_name` | Knowledge base, graph, or collection-prefix identifier. |
+| `source` | External source identifier for source-level imports, updates, or deletes. |
+| `attributes` | Optional application-specific low-sensitivity span attributes. |
+
+#### `start_span`
+
+Create a custom span that automatically includes the active observability context.
+
+```python
+from vector_graph_rag import start_span
+
+with start_span("app.custom_step", {"app.record_count": 10}):
+    run_custom_step()
+```
+
+```python
+def start_span(
+    name: str,
+    attributes: Optional[Mapping[str, Any]] = None,
+) -> Iterator[Any]
+```
+
+If OpenTelemetry is not installed, `start_span()` yields `None` and performs no tracing work.
+
+Vector Graph RAG does not record document text, prompt text, query text, generated answers, filters, or full URLs as span attributes by default. See [Observability](observability.md) for setup and span coverage.
 
 ### Methods
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Incremental Updates: incremental-updates.md
+  - Observability: observability.md
   - Architecture:
     - How It Works: how-it-works.md
     - Design Philosophy: design-philosophy.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "opentelemetry-sdk>=1.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
@@ -77,8 +78,11 @@ onnx = [
     "tokenizers>=0.15",
     "huggingface-hub>=0.20",
 ]
+observability = [
+    "opentelemetry-api>=1.0",
+]
 all = [
-    "vector-graph-rag[dev,api,hf,google,voyage,jina,mistral,ollama,local,onnx]",
+    "vector-graph-rag[dev,api,hf,google,voyage,jina,mistral,ollama,local,onnx,observability]",
 ]
 loaders = [
     "markitdown[docx,pdf]>=0.1.4",

--- a/src/vector_graph_rag/__init__.py
+++ b/src/vector_graph_rag/__init__.py
@@ -14,6 +14,7 @@ from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 from vector_graph_rag.llm.extractor import TripletExtractor
 from vector_graph_rag.llm.reranker import LLMReranker
 from vector_graph_rag.models import Document, Entity, Passage, Relation, Triplet
+from vector_graph_rag.observability import observability_context, start_span
 from vector_graph_rag.rag import VectorGraphRAG, create_rag
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
@@ -39,4 +40,6 @@ __all__ = [
     "create_rag",
     "LLMCache",
     "get_llm_cache",
+    "observability_context",
+    "start_span",
 ]

--- a/src/vector_graph_rag/api/app.py
+++ b/src/vector_graph_rag/api/app.py
@@ -14,7 +14,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, File, Form, HTTPException, Query, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from vector_graph_rag import VectorGraphRAG, __version__
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.graph.graph import Graph
+from vector_graph_rag.observability import observability_context, set_span_attributes, start_span
 from vector_graph_rag.storage.milvus import MilvusStore
 
 # ==================== Request/Response Schemas ====================
@@ -347,6 +348,42 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     app.state.settings = settings or get_settings()
     app.state.rag_instances: dict = {}  # graph_name -> VectorGraphRAG
     app.state.graph_instances: dict = {}  # graph_name -> Graph
+
+    def infer_graph_name_from_request(request: Request) -> Optional[str]:
+        """Infer graph context from safe URL structure fields."""
+        graph_name = request.query_params.get("graph_name")
+        if graph_name:
+            return graph_name
+
+        path_parts = request.url.path.strip("/").split("/")
+        if len(path_parts) >= 2 and path_parts[0] == "graph":
+            return path_parts[1]
+        return None
+
+    @app.middleware("http")
+    async def observability_middleware(request: Request, call_next):
+        """Attach request context to downstream spans."""
+        request_id = request.headers.get("x-request-id") or request.headers.get("x-correlation-id")
+        tenant_id = request.headers.get("x-tenant-id")
+        graph_name = infer_graph_name_from_request(request)
+        with observability_context(
+            request_id=request_id,
+            tenant_id=tenant_id,
+            graph_name=graph_name,
+            attributes={
+                "http.request.method": request.method,
+            },
+        ):
+            with start_span(
+                "vgrag.api.request",
+                {
+                    "vgrag.has_request_id": bool(request_id),
+                    "vgrag.has_tenant_id": bool(tenant_id),
+                },
+            ) as span:
+                response = await call_next(request)
+                set_span_attributes(span, {"http.response.status_code": response.status_code})
+                return response
 
     def get_rag(graph_name: Optional[str] = None) -> VectorGraphRAG:
         """Get or create RAG instance for a graph."""

--- a/src/vector_graph_rag/graph/knowledge_graph.py
+++ b/src/vector_graph_rag/graph/knowledge_graph.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
+from vector_graph_rag.observability import start_span
+
 if TYPE_CHECKING:
     from vector_graph_rag.storage.milvus import MilvusStore
 
@@ -372,11 +374,21 @@ class SubGraph:
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{eid}"' for eid in ids_to_fetch)
         filter_expr = f"id in [{ids_str}]"
-        results = self._store.client.query(
-            collection_name=self._store.entity_collection,
-            filter=filter_expr,
-            output_fields=["id", "text", "relation_ids", "passage_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self._store.entity_collection,
+                "vgrag.record_type": "entity",
+                "vgrag.id_count": len(ids_to_fetch),
+                "vgrag.operation": "subgraph_fetch",
+            },
+        ):
+            results = self._store.client.query(
+                collection_name=self._store.entity_collection,
+                filter=filter_expr,
+                output_fields=["id", "text", "relation_ids", "passage_ids"],
+            )
 
         for r in results:
             entity = GraphEntity(
@@ -399,19 +411,29 @@ class SubGraph:
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{rid}"' for rid in ids_to_fetch)
         filter_expr = f"id in [{ids_str}]"
-        results = self._store.client.query(
-            collection_name=self._store.relation_collection,
-            filter=filter_expr,
-            output_fields=[
-                "id",
-                "text",
-                "entity_ids",
-                "passage_ids",
-                "subject",
-                "predicate",
-                "object",
-            ],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self._store.relation_collection,
+                "vgrag.record_type": "relation",
+                "vgrag.id_count": len(ids_to_fetch),
+                "vgrag.operation": "subgraph_fetch",
+            },
+        ):
+            results = self._store.client.query(
+                collection_name=self._store.relation_collection,
+                filter=filter_expr,
+                output_fields=[
+                    "id",
+                    "text",
+                    "entity_ids",
+                    "passage_ids",
+                    "subject",
+                    "predicate",
+                    "object",
+                ],
+            )
 
         for r in results:
             text = r["text"]
@@ -450,11 +472,21 @@ class SubGraph:
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{pid}"' for pid in ids_to_fetch)
         filter_expr = f"id in [{ids_str}]"
-        results = self._store.client.query(
-            collection_name=self._store.passage_collection,
-            filter=filter_expr,
-            output_fields=["id", "text", "entity_ids", "relation_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self._store.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.id_count": len(ids_to_fetch),
+                "vgrag.operation": "subgraph_fetch",
+            },
+        ):
+            results = self._store.client.query(
+                collection_name=self._store.passage_collection,
+                filter=filter_expr,
+                output_fields=["id", "text", "entity_ids", "relation_ids"],
+            )
 
         for r in results:
             passage = GraphPassage(

--- a/src/vector_graph_rag/graph/retriever.py
+++ b/src/vector_graph_rag/graph/retriever.py
@@ -10,6 +10,7 @@ from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.graph.builder import GraphBuilder
 from vector_graph_rag.graph.knowledge_graph import SubGraph
 from vector_graph_rag.llm.extractor import EntityExtractor
+from vector_graph_rag.observability import start_span
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
 
@@ -97,7 +98,13 @@ class GraphRetriever:
 
     def _extract_query_entities(self, query: str) -> List[str]:
         """Extract named entities from the query."""
-        return self.entity_extractor.extract(query)
+        with start_span(
+            "vgrag.retrieve.extract_query_entities",
+            {
+                "vgrag.question_length": len(query),
+            },
+        ):
+            return self.entity_extractor.extract(query)
 
     def _retrieve_entities(
         self,
@@ -126,33 +133,41 @@ class GraphRetriever:
             else self.settings.entity_similarity_threshold
         )
 
-        # Embed query entities
-        query_embeddings = self.embedding_model.embed_batch(query_entities)
+        with start_span(
+            "vgrag.retrieve.entities",
+            {
+                "vgrag.query_entity_count": len(query_entities),
+                "vgrag.top_k": top_k,
+                "vgrag.similarity_threshold": threshold,
+            },
+        ):
+            # Embed query entities
+            query_embeddings = self.embedding_model.embed_batch(query_entities)
 
-        # Search for similar entities (using private method)
-        search_results = self.store._search_entities(query_embeddings, top_k=top_k)
+            # Search for similar entities (using private method)
+            search_results = self.store._search_entities(query_embeddings, top_k=top_k)
 
-        # Aggregate results with threshold filtering
-        entity_ids: List[str] = []
-        entity_texts: List[str] = []
-        scores: List[float] = []
-        seen_ids: set = set()
+            # Aggregate results with threshold filtering
+            entity_ids: List[str] = []
+            entity_texts: List[str] = []
+            scores: List[float] = []
+            seen_ids: set = set()
 
-        for result_list in search_results:
-            for result in result_list:
-                score = result["distance"]
-                # Filter by similarity threshold
-                if score <= threshold:
-                    continue
+            for result_list in search_results:
+                for result in result_list:
+                    score = result["distance"]
+                    # Filter by similarity threshold
+                    if score <= threshold:
+                        continue
 
-                entity_id = result["entity"]["id"]
-                if entity_id not in seen_ids:
-                    seen_ids.add(entity_id)
-                    entity_ids.append(entity_id)
-                    entity_texts.append(result["entity"]["text"])
-                    scores.append(score)
+                    entity_id = result["entity"]["id"]
+                    if entity_id not in seen_ids:
+                        seen_ids.add(entity_id)
+                        entity_ids.append(entity_id)
+                        entity_texts.append(result["entity"]["text"])
+                        scores.append(score)
 
-        return entity_ids, entity_texts, scores
+            return entity_ids, entity_texts, scores
 
     def _retrieve_relations(
         self,
@@ -178,25 +193,33 @@ class GraphRetriever:
             else self.settings.relation_similarity_threshold
         )
 
-        # Embed query
-        query_embedding = self.embedding_model.embed(query)
+        with start_span(
+            "vgrag.retrieve.relations",
+            {
+                "vgrag.question_length": len(query),
+                "vgrag.top_k": top_k,
+                "vgrag.similarity_threshold": threshold,
+            },
+        ):
+            # Embed query
+            query_embedding = self.embedding_model.embed(query)
 
-        # Search for similar relations (using private method)
-        results = self.store._search_relations(query_embedding, top_k=top_k)
+            # Search for similar relations (using private method)
+            results = self.store._search_relations(query_embedding, top_k=top_k)
 
-        # Filter by similarity threshold
-        relation_ids: List[str] = []
-        relation_texts: List[str] = []
-        scores: List[float] = []
+            # Filter by similarity threshold
+            relation_ids: List[str] = []
+            relation_texts: List[str] = []
+            scores: List[float] = []
 
-        for r in results:
-            score = r["distance"]
-            if score > threshold:
-                relation_ids.append(r["entity"]["id"])
-                relation_texts.append(r["entity"]["text"])
-                scores.append(score)
+            for r in results:
+                score = r["distance"]
+                if score > threshold:
+                    relation_ids.append(r["entity"]["id"])
+                    relation_texts.append(r["entity"]["text"])
+                    scores.append(score)
 
-        return relation_ids, relation_texts, scores
+            return relation_ids, relation_texts, scores
 
     def _expand_subgraph(
         self,
@@ -220,15 +243,23 @@ class GraphRetriever:
         """
         degree = degree or self.settings.expansion_degree
 
-        # Create subgraph with initial nodes
-        subgraph = SubGraph(self.store)
-        subgraph.add_entities(entity_ids)
-        subgraph.add_relations(relation_ids)
+        with start_span(
+            "vgrag.subgraph.expand",
+            {
+                "vgrag.seed_entity_count": len(entity_ids),
+                "vgrag.seed_relation_count": len(relation_ids),
+                "vgrag.expansion_degree": degree,
+            },
+        ):
+            # Create subgraph with initial nodes
+            subgraph = SubGraph(self.store)
+            subgraph.add_entities(entity_ids)
+            subgraph.add_relations(relation_ids)
 
-        # Expand by given degree
-        subgraph.expand(degree=degree)
+            # Expand by given degree
+            subgraph.expand(degree=degree)
 
-        return subgraph
+            return subgraph
 
     def _apply_eviction(
         self,
@@ -251,42 +282,58 @@ class GraphRetriever:
         """
         before_count = len(expanded_relation_ids)
 
-        if before_count == 0:
-            return [], [], False, 0
+        with start_span(
+            "vgrag.retrieve.eviction",
+            {
+                "vgrag.before_count": before_count,
+                "vgrag.relation_number_threshold": relation_number_threshold,
+            },
+        ):
+            if before_count == 0:
+                return [], [], False, 0
 
-        if before_count <= relation_number_threshold:
-            # No eviction needed, fetch all relation texts
+            if before_count <= relation_number_threshold:
+                # No eviction needed, fetch all relation texts
+                ids_str = ", ".join(f'"{rid}"' for rid in expanded_relation_ids)
+                filter_expr = f"id in [{ids_str}]"
+                results = self.store.client.query(
+                    collection_name=self.store.relation_collection,
+                    filter=filter_expr,
+                    output_fields=["id", "text"],
+                )
+                id_to_text = {r["id"]: r["text"] for r in results}
+                # Sort by ID to match HippoRAG's behavior (Milvus client.get returns sorted by ID)
+                sorted_ids = sorted(expanded_relation_ids)
+                return (
+                    sorted_ids,
+                    [id_to_text.get(rid, "") for rid in sorted_ids],
+                    False,
+                    before_count,
+                )
+
+            # Eviction needed: use vector search to filter most relevant relations
+            logger.info(
+                "Use Eviction Strategy. (%d -> %d)", before_count, relation_number_threshold
+            )
+
+            query_embedding = self.embedding_model.embed(query)
             ids_str = ", ".join(f'"{rid}"' for rid in expanded_relation_ids)
             filter_expr = f"id in [{ids_str}]"
-            results = self.store.client.query(
+
+            search_results = self.store.client.search(
                 collection_name=self.store.relation_collection,
+                data=[query_embedding],
+                limit=relation_number_threshold,
                 filter=filter_expr,
                 output_fields=["id", "text"],
-            )
-            id_to_text = {r["id"]: r["text"] for r in results}
-            # Sort by ID to match HippoRAG's behavior (Milvus client.get returns sorted by ID)
-            sorted_ids = sorted(expanded_relation_ids)
-            return sorted_ids, [id_to_text.get(rid, "") for rid in sorted_ids], False, before_count
+            )[0]
 
-        # Eviction needed: use vector search to filter most relevant relations
-        logger.info("Use Eviction Strategy. (%d -> %d)", before_count, relation_number_threshold)
+            filtered_ids = [r["entity"]["id"] for r in search_results[:relation_number_threshold]]
+            filtered_texts = [
+                r["entity"]["text"] for r in search_results[:relation_number_threshold]
+            ]
 
-        query_embedding = self.embedding_model.embed(query)
-        ids_str = ", ".join(f'"{rid}"' for rid in expanded_relation_ids)
-        filter_expr = f"id in [{ids_str}]"
-
-        search_results = self.store.client.search(
-            collection_name=self.store.relation_collection,
-            data=[query_embedding],
-            limit=relation_number_threshold,
-            filter=filter_expr,
-            output_fields=["id", "text"],
-        )[0]
-
-        filtered_ids = [r["entity"]["id"] for r in search_results[:relation_number_threshold]]
-        filtered_texts = [r["entity"]["text"] for r in search_results[:relation_number_threshold]]
-
-        return filtered_ids, filtered_texts, True, before_count
+            return filtered_ids, filtered_texts, True, before_count
 
     def _get_allowed_passage_ids(self, filter: Optional[str]) -> Optional[Set[str]]:
         """Return passage IDs matching a metadata filter, or None when no filter is set."""
@@ -307,9 +354,7 @@ class GraphRetriever:
 
         relation_data = self.store._get_relations_by_ids(relation_ids)
         allowed_relation_ids = {
-            r["id"]
-            for r in relation_data
-            if set(r.get("passage_ids", [])) & allowed_passage_ids
+            r["id"] for r in relation_data if set(r.get("passage_ids", [])) & allowed_passage_ids
         }
         return [rid for rid in relation_ids if rid in allowed_relation_ids]
 
@@ -375,64 +420,71 @@ class GraphRetriever:
             RetrievalResult with all retrieval information, including
             the SubGraph for debugging/visualization.
         """
-        allowed_passage_ids = self._get_allowed_passage_ids(filter)
+        with start_span(
+            "vgrag.retrieve.graph",
+            {
+                "vgrag.has_filter": bool(filter),
+                "vgrag.question_length": len(query),
+            },
+        ):
+            allowed_passage_ids = self._get_allowed_passage_ids(filter)
 
-        # Extract query entities
-        query_entities = self._extract_query_entities(query)
+            # Extract query entities
+            query_entities = self._extract_query_entities(query)
 
-        # Retrieve entities (with threshold filtering)
-        entity_ids, entity_texts, entity_scores = self._retrieve_entities(
-            query_entities,
-            top_k=entity_top_k,
-            similarity_threshold=entity_similarity_threshold,
-        )
+            # Retrieve entities (with threshold filtering)
+            entity_ids, entity_texts, entity_scores = self._retrieve_entities(
+                query_entities,
+                top_k=entity_top_k,
+                similarity_threshold=entity_similarity_threshold,
+            )
 
-        # Retrieve relations (with threshold filtering)
-        relation_ids, relation_texts, relation_scores = self._retrieve_relations(
-            query,
-            top_k=relation_top_k,
-            similarity_threshold=relation_similarity_threshold,
-        )
-        relation_ids, relation_texts, relation_scores = (
-            self._filter_relation_results_by_passage_ids(
-                relation_ids,
-                relation_texts,
-                relation_scores,
+            # Retrieve relations (with threshold filtering)
+            relation_ids, relation_texts, relation_scores = self._retrieve_relations(
+                query,
+                top_k=relation_top_k,
+                similarity_threshold=relation_similarity_threshold,
+            )
+            relation_ids, relation_texts, relation_scores = (
+                self._filter_relation_results_by_passage_ids(
+                    relation_ids,
+                    relation_texts,
+                    relation_scores,
+                    allowed_passage_ids,
+                )
+            )
+
+            # Expand subgraph
+            subgraph = self._expand_subgraph(entity_ids, relation_ids, degree=expansion_degree)
+
+            # Apply eviction strategy if needed
+            threshold = relation_number_threshold or self.settings.relation_number_threshold
+            filtered_expanded_relation_ids = self._filter_relations_by_passage_ids(
+                list(subgraph.relation_ids),
                 allowed_passage_ids,
             )
-        )
+            expanded_ids, expanded_texts, eviction_occurred, eviction_before = self._apply_eviction(
+                query,
+                filtered_expanded_relation_ids,
+                threshold,
+            )
 
-        # Expand subgraph
-        subgraph = self._expand_subgraph(entity_ids, relation_ids, degree=expansion_degree)
-
-        # Apply eviction strategy if needed
-        threshold = relation_number_threshold or self.settings.relation_number_threshold
-        filtered_expanded_relation_ids = self._filter_relations_by_passage_ids(
-            list(subgraph.relation_ids),
-            allowed_passage_ids,
-        )
-        expanded_ids, expanded_texts, eviction_occurred, eviction_before = self._apply_eviction(
-            query,
-            filtered_expanded_relation_ids,
-            threshold,
-        )
-
-        return RetrievalResult(
-            entity_ids=entity_ids,
-            entity_texts=entity_texts,
-            entity_scores=entity_scores,
-            relation_ids=relation_ids,
-            relation_texts=relation_texts,
-            relation_scores=relation_scores,
-            subgraph=subgraph,
-            expanded_relation_ids=expanded_ids,
-            expanded_relation_texts=expanded_texts,
-            query=query,
-            query_entities=query_entities,
-            eviction_before_count=eviction_before,
-            eviction_after_count=len(expanded_ids),
-            eviction_occurred=eviction_occurred,
-        )
+            return RetrievalResult(
+                entity_ids=entity_ids,
+                entity_texts=entity_texts,
+                entity_scores=entity_scores,
+                relation_ids=relation_ids,
+                relation_texts=relation_texts,
+                relation_scores=relation_scores,
+                subgraph=subgraph,
+                expanded_relation_ids=expanded_ids,
+                expanded_relation_texts=expanded_texts,
+                query=query,
+                query_entities=query_entities,
+                eviction_before_count=eviction_before,
+                eviction_after_count=len(expanded_ids),
+                eviction_occurred=eviction_occurred,
+            )
 
     def retrieve_passages_naive(
         self,
@@ -452,6 +504,14 @@ class GraphRetriever:
             List of passage texts.
         """
         top_k = top_k or self.settings.final_top_k
-        query_embedding = self.embedding_model.embed(query)
-        results = self.store.search_passages(query_embedding, top_k=top_k, filter=filter)
-        return [r["entity"]["text"] for r in results]
+        with start_span(
+            "vgrag.retrieve.passages_naive",
+            {
+                "vgrag.question_length": len(query),
+                "vgrag.top_k": top_k,
+                "vgrag.has_filter": bool(filter),
+            },
+        ):
+            query_embedding = self.embedding_model.embed(query)
+            results = self.store.search_passages(query_embedding, top_k=top_k, filter=filter)
+            return [r["entity"]["text"] for r in results]

--- a/src/vector_graph_rag/llm/extractor.py
+++ b/src/vector_graph_rag/llm/extractor.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
 from vector_graph_rag.models import Document, Triplet
+from vector_graph_rag.observability import start_span
 
 logger = logging.getLogger(__name__)
 
@@ -203,8 +204,17 @@ class TripletExtractor:
         if not text or not text.strip():
             return []
 
-        response = self._call_llm(text)
-        return self._parse_response(response)
+        with start_span(
+            "vgrag.extract_triplets",
+            {
+                "vgrag.llm_model": self.model,
+                "vgrag.text_length": len(text),
+                "vgrag.use_llm_cache": self.use_cache,
+            },
+        ):
+            response = self._call_llm(text)
+            triplets = self._parse_response(response)
+            return triplets
 
     def extract_from_documents(
         self,
@@ -221,14 +231,22 @@ class TripletExtractor:
         Returns:
             Documents with extracted triplets stored in metadata["triplets"].
         """
-        iterator = tqdm(documents, desc="Extracting triplets") if show_progress else documents
+        with start_span(
+            "vgrag.extract_triplets.batch",
+            {
+                "vgrag.llm_model": self.model,
+                "vgrag.document_count": len(documents),
+                "vgrag.use_llm_cache": self.use_cache,
+            },
+        ):
+            iterator = tqdm(documents, desc="Extracting triplets") if show_progress else documents
 
-        for doc in iterator:
-            triplets = self.extract(doc.page_content)
-            # Store triplets as list of [subject, predicate, object] in metadata
-            doc.metadata["triplets"] = [[t.subject, t.predicate, t.object] for t in triplets]
+            for doc in iterator:
+                triplets = self.extract(doc.page_content)
+                # Store triplets as list of [subject, predicate, object] in metadata
+                doc.metadata["triplets"] = [[t.subject, t.predicate, t.object] for t in triplets]
 
-        return documents
+            return documents
 
 
 class EntityExtractor:
@@ -331,45 +349,54 @@ class EntityExtractor:
         Returns:
             List of entity strings.
         """
-        # Check TSV cache first (HippoRAG format)
-        if question in self.ner_tsv_cache:
-            entities = self.ner_tsv_cache[question]
-            return [processing_phrases(str(e)) for e in entities if e]
+        with start_span(
+            "vgrag.extract_query_entities",
+            {
+                "vgrag.llm_model": self.model,
+                "vgrag.question_length": len(question),
+                "vgrag.use_llm_cache": self.use_cache,
+                "vgrag.has_ner_tsv_cache": bool(self.ner_tsv_cache),
+            },
+        ):
+            # Check TSV cache first (HippoRAG format)
+            if question in self.ner_tsv_cache:
+                entities = self.ner_tsv_cache[question]
+                return [processing_phrases(str(e)) for e in entities if e]
 
-        prompt = self._build_prompt(question)
+            prompt = self._build_prompt(question)
 
-        # Check LLM cache
-        if self.cache:
-            cached = self.cache.get(self.model, prompt, temperature=0)
-            if cached is not None:
-                try:
-                    data = json.loads(cached)
-                    entities = data.get("named_entities", data.get("entities", []))
-                    return [processing_phrases(str(e)) for e in entities if e]
-                except (json.JSONDecodeError, KeyError):
-                    pass
+            # Check LLM cache
+            if self.cache:
+                cached = self.cache.get(self.model, prompt, temperature=0)
+                if cached is not None:
+                    try:
+                        data = json.loads(cached)
+                        entities = data.get("named_entities", data.get("entities", []))
+                        return [processing_phrases(str(e)) for e in entities if e]
+                    except (json.JSONDecodeError, KeyError):
+                        pass
 
-        response = self.client.chat.completions.create(
-            model=self.model,
-            temperature=0,
-            response_format={"type": "json_object"},
-            messages=[
-                {"role": "system", "content": NER_SYSTEM_PROMPT},
-                {"role": "user", "content": NER_ONE_SHOT_INPUT},
-                {"role": "assistant", "content": NER_ONE_SHOT_OUTPUT},
-                {"role": "user", "content": NER_TEMPLATE.format(question)},
-            ],
-        )
+            response = self.client.chat.completions.create(
+                model=self.model,
+                temperature=0,
+                response_format={"type": "json_object"},
+                messages=[
+                    {"role": "system", "content": NER_SYSTEM_PROMPT},
+                    {"role": "user", "content": NER_ONE_SHOT_INPUT},
+                    {"role": "assistant", "content": NER_ONE_SHOT_OUTPUT},
+                    {"role": "user", "content": NER_TEMPLATE.format(question)},
+                ],
+            )
 
-        content = response.choices[0].message.content or "{}"
+            content = response.choices[0].message.content or "{}"
 
-        # Store in cache
-        if self.cache:
-            self.cache.set(self.model, prompt, content, temperature=0)
+            # Store in cache
+            if self.cache:
+                self.cache.set(self.model, prompt, content, temperature=0)
 
-        try:
-            data = json.loads(content)
-            entities = data.get("named_entities", data.get("entities", []))
-            return [processing_phrases(str(e)) for e in entities if e]
-        except (json.JSONDecodeError, KeyError):
-            return []
+            try:
+                data = json.loads(content)
+                entities = data.get("named_entities", data.get("entities", []))
+                return [processing_phrases(str(e)) for e in entities if e]
+            except (json.JSONDecodeError, KeyError):
+                return []

--- a/src/vector_graph_rag/llm/reranker.py
+++ b/src/vector_graph_rag/llm/reranker.py
@@ -10,6 +10,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from vector_graph_rag.config import Settings, get_settings
 from vector_graph_rag.llm.cache import LLMCache, get_llm_cache
+from vector_graph_rag.observability import start_span
 
 RERANK_EXAMPLE_1_INPUT = """I will provide you with a set of relationship descriptions from a knowledge graph. Select exactly 5 relationships most useful for answering this multi-hop question.
 
@@ -264,23 +265,32 @@ class LLMReranker:
         if not relation_ids:
             return [], []
 
-        # Format relations
-        relation_descriptions = self._format_relations(relation_ids, relation_texts)
+        with start_span(
+            "vgrag.rerank",
+            {
+                "vgrag.llm_model": self.model,
+                "vgrag.question_length": len(query),
+                "vgrag.candidate_relation_count": len(relation_ids),
+                "vgrag.use_llm_cache": self.use_cache,
+            },
+        ):
+            # Format relations
+            relation_descriptions = self._format_relations(relation_ids, relation_texts)
 
-        # Call LLM
-        response = self._call_llm(query, relation_descriptions)
+            # Call LLM
+            response = self._call_llm(query, relation_descriptions)
 
-        # Parse response
-        valid_ids = set(relation_ids)
-        selected_ids = self._parse_response(response, valid_ids, relation_ids, relation_texts)
+            # Parse response
+            valid_ids = set(relation_ids)
+            selected_ids = self._parse_response(response, valid_ids, relation_ids, relation_texts)
 
-        # No fallback - return whatever LLM selected (same as current project)
+            # No fallback - return whatever LLM selected (same as current project)
 
-        # Get corresponding texts
-        id_to_text = dict(zip(relation_ids, relation_texts))
-        selected_texts = [id_to_text[rid] for rid in selected_ids if rid in id_to_text]
+            # Get corresponding texts
+            id_to_text = dict(zip(relation_ids, relation_texts))
+            selected_texts = [id_to_text[rid] for rid in selected_ids if rid in id_to_text]
 
-        return selected_ids, selected_texts
+            return selected_ids, selected_texts
 
 
 class AnswerGenerator:
@@ -341,31 +351,41 @@ Answer:"""
         Returns:
             Generated answer string.
         """
-        context = "\n\n".join(passages)
-        prompt = self.ANSWER_PROMPT.format(question=query, context=context)
+        with start_span(
+            "vgrag.answer",
+            {
+                "vgrag.llm_model": self.model,
+                "vgrag.question_length": len(query),
+                "vgrag.passage_count": len(passages),
+                "vgrag.context_length": sum(len(passage) for passage in passages),
+                "vgrag.use_llm_cache": self.use_cache,
+            },
+        ):
+            context = "\n\n".join(passages)
+            prompt = self.ANSWER_PROMPT.format(question=query, context=context)
 
-        # Check cache
-        if self.cache:
-            cached = self.cache.get(self.model, prompt, temperature=0)
-            if cached is not None:
-                return cached
+            # Check cache
+            if self.cache:
+                cached = self.cache.get(self.model, prompt, temperature=0)
+                if cached is not None:
+                    return cached
 
-        messages = [{"role": "user", "content": prompt}]
+            messages = [{"role": "user", "content": prompt}]
 
-        # Build API call kwargs - gpt-5 series doesn't support temperature parameter
-        api_kwargs = {
-            "model": self.model,
-            "messages": messages,
-        }
-        if not self.model.startswith("gpt-5"):
-            api_kwargs["temperature"] = 0
+            # Build API call kwargs - gpt-5 series doesn't support temperature parameter
+            api_kwargs = {
+                "model": self.model,
+                "messages": messages,
+            }
+            if not self.model.startswith("gpt-5"):
+                api_kwargs["temperature"] = 0
 
-        response = self.client.chat.completions.create(**api_kwargs)
+            response = self.client.chat.completions.create(**api_kwargs)
 
-        result = response.choices[0].message.content or "I don't know."
+            result = response.choices[0].message.content or "I don't know."
 
-        # Store in cache
-        if self.cache:
-            self.cache.set(self.model, prompt, result, temperature=0)
+            # Store in cache
+            if self.cache:
+                self.cache.set(self.model, prompt, result, temperature=0)
 
-        return result
+            return result

--- a/src/vector_graph_rag/loaders/__init__.py
+++ b/src/vector_graph_rag/loaders/__init__.py
@@ -14,6 +14,8 @@ from typing import List, Optional
 from langchain_core.documents import Document
 from pydantic import BaseModel, ConfigDict
 
+from vector_graph_rag.observability import observability_context, start_span
+
 from .chunker import TextChunker
 from .converter import ConversionResult, DocumentConverter, DocumentConverterProtocol
 from .docling import DoclingConverter
@@ -87,54 +89,81 @@ class DocumentImporter:
         Returns:
             LoaderResult with Documents and any errors
         """
-        all_documents = []
-        all_errors = []
+        with start_span(
+            "vgrag.import_sources",
+            {
+                "vgrag.source_count": len(sources),
+                "vgrag.chunk_documents": self.chunker is not None,
+            },
+        ):
+            all_documents = []
+            all_errors = []
 
-        for source in sources:
-            result = self._import_single(source)
-            all_documents.extend(result.documents)
-            all_errors.extend(result.errors)
+            for source in sources:
+                with observability_context(source=source):
+                    result = self._import_single(source)
+                all_documents.extend(result.documents)
+                all_errors.extend(result.errors)
 
-        # Apply chunking if enabled
-        if self.chunker and all_documents:
-            all_documents = self.chunker.chunk_batch(all_documents)
+            # Apply chunking if enabled
+            if self.chunker and all_documents:
+                with start_span(
+                    "vgrag.chunk_documents",
+                    {
+                        "vgrag.document_count": len(all_documents),
+                        "vgrag.chunk_size": self.chunker.chunk_size,
+                        "vgrag.chunk_overlap": self.chunker.chunk_overlap,
+                    },
+                ):
+                    all_documents = self.chunker.chunk_batch(all_documents)
 
-        return LoaderResult(documents=all_documents, errors=all_errors)
+            return LoaderResult(documents=all_documents, errors=all_errors)
 
     def _import_single(self, source: str) -> ConversionResult:
         """Import a single source (file or URL)."""
-        # Check if URL
-        if source.startswith(("http://", "https://")):
-            return self.url_fetcher.fetch(source)
+        with start_span(
+            "vgrag.import_source",
+            {
+                "vgrag.source_type": "url"
+                if source.startswith(("http://", "https://"))
+                else Path(source).suffix.lower().lstrip("."),
+            },
+        ):
+            # Check if URL
+            if source.startswith(("http://", "https://")):
+                return self.url_fetcher.fetch(source)
 
-        # Check if file exists
-        path = Path(source)
-        if not path.exists():
-            return ConversionResult(documents=[], errors=[f"File not found: {source}"])
+            # Check if file exists
+            path = Path(source)
+            if not path.exists():
+                return ConversionResult(documents=[], errors=[f"File not found: {source}"])
 
-        # Check if supported
-        ext = path.suffix.lower()
-        if ext not in self.supported_extensions:
-            return ConversionResult(documents=[], errors=[f"Unsupported file type: {ext}"])
+            # Check if supported
+            ext = path.suffix.lower()
+            if ext not in self.supported_extensions:
+                return ConversionResult(documents=[], errors=[f"Unsupported file type: {ext}"])
 
-        # Handle different file types
-        if ext in self.TEXT_EXTENSIONS:
-            # Direct passthrough for text files
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    content = f.read()
-                doc = Document(
-                    page_content=content,
-                    metadata={
-                        "source": str(path),
-                        "source_type": ext[1:],  # Remove dot
-                    },
-                )
-                return ConversionResult(documents=[doc])
-            except Exception as e:
-                return ConversionResult(documents=[], errors=[f"Failed to read {source}: {str(e)}"])
-        else:
-            return self.converter.convert(source)
+            # Handle different file types
+            if ext in self.TEXT_EXTENSIONS:
+                # Direct passthrough for text files
+                try:
+                    with open(path, "r", encoding="utf-8") as f:
+                        content = f.read()
+                    doc = Document(
+                        page_content=content,
+                        metadata={
+                            "source": str(path),
+                            "source_type": ext[1:],  # Remove dot
+                        },
+                    )
+                    return ConversionResult(documents=[doc])
+                except Exception as e:
+                    return ConversionResult(
+                        documents=[],
+                        errors=[f"Failed to read {source}: {str(e)}"],
+                    )
+            else:
+                return self.converter.convert(source)
 
     def import_text(self, text: str, source: str = "text_input") -> LoaderResult:
         """
@@ -147,13 +176,31 @@ class DocumentImporter:
         Returns:
             LoaderResult with Document
         """
-        doc = Document(page_content=text, metadata={"source": source, "source_type": "text"})
+        with observability_context(source=source):
+            with start_span(
+                "vgrag.import_text",
+                {
+                    "vgrag.text_length": len(text),
+                    "vgrag.chunk_documents": self.chunker is not None,
+                },
+            ):
+                doc = Document(
+                    page_content=text, metadata={"source": source, "source_type": "text"}
+                )
 
-        documents = [doc]
-        if self.chunker:
-            documents = self.chunker.chunk_batch(documents)
+                documents = [doc]
+                if self.chunker:
+                    with start_span(
+                        "vgrag.chunk_documents",
+                        {
+                            "vgrag.document_count": len(documents),
+                            "vgrag.chunk_size": self.chunker.chunk_size,
+                            "vgrag.chunk_overlap": self.chunker.chunk_overlap,
+                        },
+                    ):
+                        documents = self.chunker.chunk_batch(documents)
 
-        return LoaderResult(documents=documents)
+                return LoaderResult(documents=documents)
 
 
 # Convenience exports

--- a/src/vector_graph_rag/loaders/converter.py
+++ b/src/vector_graph_rag/loaders/converter.py
@@ -8,6 +8,8 @@ from typing import List, Protocol
 from langchain_core.documents import Document
 from pydantic import BaseModel, ConfigDict
 
+from vector_graph_rag.observability import observability_context, start_span
+
 try:
     from markitdown import MarkItDown
 
@@ -69,25 +71,36 @@ class DocumentConverter:
             ConversionResult with Document(s) and any errors
         """
         path = Path(source)
-        if not path.exists():
-            return ConversionResult(documents=[], errors=[f"File not found: {source}"])
-
-        try:
-            result = self.md.convert(str(path))
-
-            doc = Document(
-                page_content=result.text_content,
-                metadata={
-                    "source": str(path),
-                    "source_type": self._get_source_type(path),
-                    "title": getattr(result, "title", None),
+        with observability_context(source=str(path)):
+            with start_span(
+                "vgrag.convert_document",
+                {
+                    "vgrag.parser": "markitdown",
+                    "vgrag.source_type": path.suffix.lower().lstrip("."),
                 },
-            )
+            ):
+                if not path.exists():
+                    return ConversionResult(documents=[], errors=[f"File not found: {source}"])
 
-            return ConversionResult(documents=[doc])
+                try:
+                    result = self.md.convert(str(path))
 
-        except Exception as e:
-            return ConversionResult(documents=[], errors=[f"Failed to convert {source}: {str(e)}"])
+                    doc = Document(
+                        page_content=result.text_content,
+                        metadata={
+                            "source": str(path),
+                            "source_type": self._get_source_type(path),
+                            "title": getattr(result, "title", None),
+                        },
+                    )
+
+                    return ConversionResult(documents=[doc])
+
+                except Exception as e:
+                    return ConversionResult(
+                        documents=[],
+                        errors=[f"Failed to convert {source}: {str(e)}"],
+                    )
 
     def convert_batch(self, sources: List[str]) -> ConversionResult:
         """Convert multiple files."""

--- a/src/vector_graph_rag/loaders/docling.py
+++ b/src/vector_graph_rag/loaders/docling.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional
 
 from langchain_core.documents import Document
 
+from vector_graph_rag.observability import observability_context, start_span
+
 from .converter import ConversionResult
 
 try:
@@ -84,45 +86,56 @@ class DoclingConverter:
             ConversionResult with one Markdown document or conversion errors.
         """
         path = Path(source)
-        if not path.exists():
-            return ConversionResult(documents=[], errors=[f"File not found: {source}"])
-
-        ext = path.suffix.lower()
-        if ext not in self.supported_extensions:
-            return ConversionResult(
-                documents=[], errors=[f"Unsupported file type for Docling: {ext}"]
-            )
-
-        try:
-            result = self.converter.convert(str(path))
-            docling_document = getattr(result, "document", None)
-            if docling_document is None:
-                return ConversionResult(
-                    documents=[],
-                    errors=[f"Docling completed but no document output was found for {source}"],
-                )
-
-            content = docling_document.export_to_markdown(**self.export_kwargs).strip()
-            if not content:
-                return ConversionResult(
-                    documents=[],
-                    errors=[f"Docling produced an empty Markdown document for {source}"],
-                )
-
-            doc = Document(
-                page_content=content,
-                metadata={
-                    "source": str(path),
-                    "source_type": ext[1:],
-                    "parser": "docling",
+        with observability_context(source=str(path)):
+            with start_span(
+                "vgrag.convert_document",
+                {
+                    "vgrag.parser": "docling",
+                    "vgrag.source_type": path.suffix.lower().lstrip("."),
                 },
-            )
-            return ConversionResult(documents=[doc])
+            ):
+                if not path.exists():
+                    return ConversionResult(documents=[], errors=[f"File not found: {source}"])
 
-        except Exception as exc:
-            return ConversionResult(
-                documents=[], errors=[f"Failed to convert {source} with Docling: {str(exc)}"]
-            )
+                ext = path.suffix.lower()
+                if ext not in self.supported_extensions:
+                    return ConversionResult(
+                        documents=[], errors=[f"Unsupported file type for Docling: {ext}"]
+                    )
+
+                try:
+                    result = self.converter.convert(str(path))
+                    docling_document = getattr(result, "document", None)
+                    if docling_document is None:
+                        return ConversionResult(
+                            documents=[],
+                            errors=[
+                                f"Docling completed but no document output was found for {source}"
+                            ],
+                        )
+
+                    content = docling_document.export_to_markdown(**self.export_kwargs).strip()
+                    if not content:
+                        return ConversionResult(
+                            documents=[],
+                            errors=[f"Docling produced an empty Markdown document for {source}"],
+                        )
+
+                    doc = Document(
+                        page_content=content,
+                        metadata={
+                            "source": str(path),
+                            "source_type": ext[1:],
+                            "parser": "docling",
+                        },
+                    )
+                    return ConversionResult(documents=[doc])
+
+                except Exception as exc:
+                    return ConversionResult(
+                        documents=[],
+                        errors=[f"Failed to convert {source} with Docling: {str(exc)}"],
+                    )
 
     def convert_batch(self, sources: List[str]) -> ConversionResult:
         """Convert multiple files."""

--- a/src/vector_graph_rag/loaders/mineru.py
+++ b/src/vector_graph_rag/loaders/mineru.py
@@ -12,6 +12,8 @@ from typing import List, Optional
 
 from langchain_core.documents import Document
 
+from vector_graph_rag.observability import observability_context, start_span
+
 from .converter import ConversionResult
 
 
@@ -82,73 +84,85 @@ class MinerUConverter:
             ConversionResult with one Markdown document or conversion errors.
         """
         path = Path(source)
-        if not path.exists():
-            return ConversionResult(documents=[], errors=[f"File not found: {source}"])
-
-        ext = path.suffix.lower()
-        if ext not in self.supported_extensions:
-            return ConversionResult(
-                documents=[], errors=[f"Unsupported file type for MinerU: {ext}"]
-            )
-
-        temp_dir = None
-        if self.output_dir is None:
-            temp_dir = tempfile.TemporaryDirectory()
-            output_root = Path(temp_dir.name)
-        else:
-            output_root = self.output_dir
-            output_root.mkdir(parents=True, exist_ok=True)
-
-        try:
-            command = [
-                self._resolve_command(),
-                "-p",
-                str(path),
-                "-o",
-                str(output_root),
-                *self.extra_args,
-            ]
-            result = self._run_command(command)
-            if result.returncode != 0:
-                details = (result.stderr or result.stdout or "").strip()
-                message = f"MinerU failed to convert {source}"
-                if details:
-                    message = f"{message}: {details}"
-                return ConversionResult(documents=[], errors=[message])
-
-            markdown_path = self._find_markdown_output(output_root, path)
-            if markdown_path is None:
-                return ConversionResult(
-                    documents=[],
-                    errors=[f"MinerU completed but no Markdown output was found for {source}"],
-                )
-
-            content = markdown_path.read_text(encoding="utf-8").strip()
-            if not content:
-                return ConversionResult(
-                    documents=[],
-                    errors=[f"MinerU produced an empty Markdown document for {source}"],
-                )
-
-            doc = Document(
-                page_content=content,
-                metadata={
-                    "source": str(path),
-                    "source_type": ext[1:],
-                    "parser": "mineru",
+        with observability_context(source=str(path)):
+            with start_span(
+                "vgrag.convert_document",
+                {
+                    "vgrag.parser": "mineru",
+                    "vgrag.source_type": path.suffix.lower().lstrip("."),
                 },
-            )
-            return ConversionResult(documents=[doc])
+            ):
+                if not path.exists():
+                    return ConversionResult(documents=[], errors=[f"File not found: {source}"])
 
-        except subprocess.TimeoutExpired:
-            return ConversionResult(documents=[], errors=[f"MinerU timed out converting {source}"])
-        except Exception as exc:
-            return ConversionResult(
-                documents=[], errors=[f"Failed to convert {source}: {str(exc)}"]
-            )
-        finally:
-            if temp_dir is not None:
-                temp_dir.cleanup()
+                ext = path.suffix.lower()
+                if ext not in self.supported_extensions:
+                    return ConversionResult(
+                        documents=[], errors=[f"Unsupported file type for MinerU: {ext}"]
+                    )
+
+                temp_dir = None
+                if self.output_dir is None:
+                    temp_dir = tempfile.TemporaryDirectory()
+                    output_root = Path(temp_dir.name)
+                else:
+                    output_root = self.output_dir
+                    output_root.mkdir(parents=True, exist_ok=True)
+
+                try:
+                    command = [
+                        self._resolve_command(),
+                        "-p",
+                        str(path),
+                        "-o",
+                        str(output_root),
+                        *self.extra_args,
+                    ]
+                    result = self._run_command(command)
+                    if result.returncode != 0:
+                        details = (result.stderr or result.stdout or "").strip()
+                        message = f"MinerU failed to convert {source}"
+                        if details:
+                            message = f"{message}: {details}"
+                        return ConversionResult(documents=[], errors=[message])
+
+                    markdown_path = self._find_markdown_output(output_root, path)
+                    if markdown_path is None:
+                        return ConversionResult(
+                            documents=[],
+                            errors=[
+                                f"MinerU completed but no Markdown output was found for {source}"
+                            ],
+                        )
+
+                    content = markdown_path.read_text(encoding="utf-8").strip()
+                    if not content:
+                        return ConversionResult(
+                            documents=[],
+                            errors=[f"MinerU produced an empty Markdown document for {source}"],
+                        )
+
+                    doc = Document(
+                        page_content=content,
+                        metadata={
+                            "source": str(path),
+                            "source_type": ext[1:],
+                            "parser": "mineru",
+                        },
+                    )
+                    return ConversionResult(documents=[doc])
+
+                except subprocess.TimeoutExpired:
+                    return ConversionResult(
+                        documents=[], errors=[f"MinerU timed out converting {source}"]
+                    )
+                except Exception as exc:
+                    return ConversionResult(
+                        documents=[], errors=[f"Failed to convert {source}: {str(exc)}"]
+                    )
+                finally:
+                    if temp_dir is not None:
+                        temp_dir.cleanup()
 
     def _run_command(self, command: List[str]) -> subprocess.CompletedProcess[str]:
         """Run MinerU and clean up child processes on timeout."""

--- a/src/vector_graph_rag/loaders/url_fetcher.py
+++ b/src/vector_graph_rag/loaders/url_fetcher.py
@@ -10,6 +10,8 @@ import requests
 import trafilatura
 from langchain_core.documents import Document
 
+from vector_graph_rag.observability import observability_context, start_span
+
 from .converter import ConversionResult, DocumentConverter, DocumentConverterProtocol
 
 
@@ -47,50 +49,57 @@ class URLFetcher:
 
     def _is_pdf_url(self, url: str) -> bool:
         """Check if URL points to a PDF file."""
-        # Check by URL extension
-        if url.lower().endswith(".pdf"):
-            return True
+        with start_span("vgrag.url.detect_type"):
+            # Check by URL extension
+            if url.lower().endswith(".pdf"):
+                return True
 
-        # Check by Content-Type header
-        try:
-            response = requests.head(url, headers=self.headers, timeout=5, allow_redirects=True)
-            content_type = response.headers.get("Content-Type", "").lower()
-            return "application/pdf" in content_type
-        except Exception:
-            return False
+            # Check by Content-Type header
+            try:
+                response = requests.head(url, headers=self.headers, timeout=5, allow_redirects=True)
+                content_type = response.headers.get("Content-Type", "").lower()
+                return "application/pdf" in content_type
+            except Exception:
+                return False
 
     def _fetch_pdf_url(self, url: str) -> ConversionResult:
         """Download and convert a PDF URL."""
-        try:
-            # Download PDF to temporary file
-            response = requests.get(url, headers=self.headers, timeout=self.timeout)
-            response.raise_for_status()
-
-            # Create temporary file
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
-                tmp_file.write(response.content)
-                tmp_path = tmp_file.name
-
-            # Convert PDF using DocumentConverter
-            result = self.converter.convert(tmp_path)
-
-            # Update metadata to reflect URL source
-            for doc in result.documents:
-                doc.metadata["source"] = url
-                doc.metadata["source_type"] = "pdf_url"
-
-            # Clean up temporary file
+        with start_span(
+            "vgrag.fetch_url",
+            {
+                "vgrag.source_type": "pdf_url",
+            },
+        ):
             try:
-                Path(tmp_path).unlink()
-            except Exception:
-                pass
+                # Download PDF to temporary file
+                response = requests.get(url, headers=self.headers, timeout=self.timeout)
+                response.raise_for_status()
 
-            return result
+                # Create temporary file
+                with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
+                    tmp_file.write(response.content)
+                    tmp_path = tmp_file.name
 
-        except Exception as e:
-            return ConversionResult(
-                documents=[], errors=[f"Failed to fetch PDF from {url}: {str(e)}"]
-            )
+                # Convert PDF using DocumentConverter
+                result = self.converter.convert(tmp_path)
+
+                # Update metadata to reflect URL source
+                for doc in result.documents:
+                    doc.metadata["source"] = url
+                    doc.metadata["source_type"] = "pdf_url"
+
+                # Clean up temporary file
+                try:
+                    Path(tmp_path).unlink()
+                except Exception:
+                    pass
+
+                return result
+
+            except Exception as e:
+                return ConversionResult(
+                    documents=[], errors=[f"Failed to fetch PDF from {url}: {str(e)}"]
+                )
 
     def fetch(self, url: str) -> ConversionResult:
         """
@@ -102,44 +111,60 @@ class URLFetcher:
         Returns:
             ConversionResult with Document
         """
-        try:
-            # Check if URL points to PDF
-            if self._is_pdf_url(url):
-                return self._fetch_pdf_url(url)
-
-            # Fetch HTML content for web pages with custom headers
-            response = requests.get(
-                url, headers=self.headers, timeout=self.timeout, allow_redirects=True
-            )
-            response.raise_for_status()
-            html_content = response.text
-
-            if not html_content:
-                return ConversionResult(documents=[], errors=[f"Failed to fetch URL: {url}"])
-
-            # Extract content as markdown (best option for text-focused RAG)
-            content = trafilatura.extract(
-                html_content,
-                output_format="markdown",
-                include_links=self.include_links,
-                include_images=self.include_images,
-            )
-
-            if not content:
-                return ConversionResult(documents=[], errors=[f"No content extracted from: {url}"])
-
-            doc = Document(
-                page_content=content,
-                metadata={
-                    "source": url,
-                    "source_type": "url",
+        with observability_context(source=url):
+            with start_span(
+                "vgrag.fetch_url",
+                {
+                    "vgrag.source_type": "url",
+                    "vgrag.include_links": self.include_links,
+                    "vgrag.include_images": self.include_images,
                 },
-            )
+            ):
+                try:
+                    # Check if URL points to PDF
+                    if self._is_pdf_url(url):
+                        return self._fetch_pdf_url(url)
 
-            return ConversionResult(documents=[doc])
+                    # Fetch HTML content for web pages with custom headers
+                    response = requests.get(
+                        url, headers=self.headers, timeout=self.timeout, allow_redirects=True
+                    )
+                    response.raise_for_status()
+                    html_content = response.text
 
-        except Exception as e:
-            return ConversionResult(documents=[], errors=[f"Failed to fetch {url}: {str(e)}"])
+                    if not html_content:
+                        return ConversionResult(
+                            documents=[], errors=[f"Failed to fetch URL: {url}"]
+                        )
+
+                    # Extract content as markdown (best option for text-focused RAG)
+                    content = trafilatura.extract(
+                        html_content,
+                        output_format="markdown",
+                        include_links=self.include_links,
+                        include_images=self.include_images,
+                    )
+
+                    if not content:
+                        return ConversionResult(
+                            documents=[],
+                            errors=[f"No content extracted from: {url}"],
+                        )
+
+                    doc = Document(
+                        page_content=content,
+                        metadata={
+                            "source": url,
+                            "source_type": "url",
+                        },
+                    )
+
+                    return ConversionResult(documents=[doc])
+
+                except Exception as e:
+                    return ConversionResult(
+                        documents=[], errors=[f"Failed to fetch {url}: {str(e)}"]
+                    )
 
     def fetch_batch(self, urls: list[str]) -> ConversionResult:
         """Fetch multiple URLs."""

--- a/src/vector_graph_rag/observability.py
+++ b/src/vector_graph_rag/observability.py
@@ -1,0 +1,134 @@
+"""Optional OpenTelemetry helpers for Vector Graph RAG."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Dict, Iterator, Mapping, Optional
+
+try:  # pragma: no cover - exercised when the optional dependency is installed.
+    from opentelemetry import trace
+except ImportError:  # pragma: no cover - the no-op path is covered by unit tests.
+    trace = None  # type: ignore[assignment]
+
+
+AttributeValue = str | bool | int | float | list[str] | list[bool] | list[int] | list[float]
+
+_TRACER_NAME = "vector_graph_rag"
+_OBSERVABILITY_CONTEXT: ContextVar[Dict[str, AttributeValue]] = ContextVar(
+    "vector_graph_rag_observability_context",
+    default={},
+)
+
+
+def _is_supported_scalar(value: Any) -> bool:
+    """Return whether a value is safe for OpenTelemetry span attributes."""
+    return isinstance(value, (str, bool, int, float))
+
+
+def _normalize_attribute_value(value: Any) -> Optional[AttributeValue]:
+    """Normalize a value to an OpenTelemetry-compatible attribute value."""
+    if value is None:
+        return None
+    if _is_supported_scalar(value):
+        return value
+    if isinstance(value, tuple):
+        value = list(value)
+    if isinstance(value, list) and all(_is_supported_scalar(item) for item in value):
+        return value
+    return str(value)
+
+
+def _clean_attributes(attributes: Optional[Mapping[str, Any]]) -> Dict[str, AttributeValue]:
+    """Return attributes with empty keys and None values removed."""
+    cleaned: Dict[str, AttributeValue] = {}
+    if not attributes:
+        return cleaned
+
+    for key, value in attributes.items():
+        if not isinstance(key, str) or not key.strip():
+            continue
+        normalized = _normalize_attribute_value(value)
+        if normalized is not None:
+            cleaned[key.strip()] = normalized
+    return cleaned
+
+
+def _standard_context_attributes(
+    request_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Dict[str, AttributeValue]:
+    """Build namespaced observability attributes for common request context."""
+    attributes: Dict[str, AttributeValue] = {}
+    if request_id:
+        attributes["vgrag.request_id"] = request_id
+    if tenant_id:
+        attributes["vgrag.tenant_id"] = tenant_id
+    if graph_name:
+        attributes["vgrag.graph_name"] = graph_name
+    if source:
+        attributes["vgrag.source"] = source
+    return attributes
+
+
+def get_observability_attributes() -> Dict[str, AttributeValue]:
+    """Return the current observability context attributes."""
+    return dict(_OBSERVABILITY_CONTEXT.get())
+
+
+@contextmanager
+def observability_context(
+    request_id: Optional[str] = None,
+    tenant_id: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    source: Optional[str] = None,
+    attributes: Optional[Mapping[str, Any]] = None,
+) -> Iterator[None]:
+    """Attach low-sensitivity attributes to spans created inside the context."""
+    context_attributes = {
+        **_standard_context_attributes(
+            request_id=request_id,
+            tenant_id=tenant_id,
+            graph_name=graph_name,
+            source=source,
+        ),
+        **_clean_attributes(attributes),
+    }
+    current = get_observability_attributes()
+    token = _OBSERVABILITY_CONTEXT.set({**current, **context_attributes})
+    try:
+        yield
+    finally:
+        _OBSERVABILITY_CONTEXT.reset(token)
+
+
+def set_span_attributes(span: Any, attributes: Optional[Mapping[str, Any]]) -> None:
+    """Set supported attributes on a span-like object."""
+    if span is None:
+        return
+    for key, value in _clean_attributes(attributes).items():
+        span.set_attribute(key, value)
+
+
+@contextmanager
+def start_span(name: str, attributes: Optional[Mapping[str, Any]] = None) -> Iterator[Any]:
+    """Start an OpenTelemetry span if the optional dependency is installed."""
+    if trace is None:
+        yield None
+        return
+
+    tracer = trace.get_tracer(_TRACER_NAME)
+    with tracer.start_as_current_span(name) as span:
+        set_span_attributes(span, get_observability_attributes())
+        set_span_attributes(span, attributes)
+        yield span
+
+
+__all__ = [
+    "get_observability_attributes",
+    "observability_context",
+    "set_span_attributes",
+    "start_span",
+]

--- a/src/vector_graph_rag/rag.py
+++ b/src/vector_graph_rag/rag.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import uuid
 import warnings
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple
 
 from vector_graph_rag.config import Settings
@@ -24,6 +25,7 @@ from vector_graph_rag.models import (
     RerankResult,
     RetrievalDetail,
 )
+from vector_graph_rag.observability import observability_context, start_span
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 from vector_graph_rag.storage.milvus import MilvusStore
 
@@ -179,6 +181,27 @@ class VectorGraphRAG:
                 embedding_model=self._embedding_model,
             )
         return self._retriever
+
+    @contextmanager
+    def _observed_operation(
+        self,
+        name: str,
+        attributes: Optional[Dict[str, Any]] = None,
+        source: Optional[str] = None,
+    ):
+        """Start a top-level operation span with graph context."""
+        operation = name.removeprefix("vgrag.")
+        span_attributes = {
+            "vgrag.operation": operation,
+            "vgrag.collection_prefix": self.settings.collection_prefix,
+            "vgrag.llm_model": self.settings.llm_model,
+            "vgrag.embedding_provider": self.settings.embedding_provider,
+            "vgrag.embedding_model": self.settings.embedding_model,
+            **(attributes or {}),
+        }
+        with observability_context(graph_name=self.settings.collection_prefix, source=source):
+            with start_span(name, span_attributes):
+                yield
 
     def _get_passages_from_subgraph(self, subgraph: SubGraph) -> List[str]:
         """
@@ -382,7 +405,13 @@ class VectorGraphRAG:
         Dict[str, Dict[str, Any]],
     ]:
         """Build graph records and embeddings for a document batch."""
-        result = builder.build_from_documents(documents)
+        with start_span(
+            "vgrag.graph.build",
+            {
+                "vgrag.document_count": len(documents),
+            },
+        ):
+            result = builder.build_from_documents(documents)
 
         if show_progress:
             logger.info("Generating embeddings...")
@@ -431,62 +460,70 @@ class VectorGraphRAG:
         show_progress: bool,
     ) -> None:
         """Insert a full graph after collections have been recreated."""
-        entity_metadatas = []
-        for eid in builder.entity_ids:
-            entity_metadatas.append(
-                {
-                    "relation_ids": builder.entity_to_relation_ids.get(eid, []),
-                    "passage_ids": builder.entity_to_passage_ids.get(eid, []),
-                }
-            )
-
-        relation_metadatas = []
-        for rid in builder.relation_ids:
-            triplet = builder.relation_id_to_triplet.get(rid)
-            metadata = {
-                "entity_ids": builder.relation_to_entity_ids.get(rid, []),
-                "passage_ids": builder.relation_to_passage_ids.get(rid, []),
-            }
-            if triplet:
-                metadata["subject"] = triplet.subject
-                metadata["predicate"] = triplet.predicate
-                metadata["object"] = triplet.object
-            relation_metadatas.append(metadata)
-
-        passage_metadatas = []
-        for pid in builder.passage_ids:
-            passage_metadatas.append(
-                self._merge_passage_metadata(
-                    passage_user_metadatas.get(pid, {}),
-                    builder.passage_to_entity_ids.get(pid, []),
-                    builder.passage_to_relation_ids.get(pid, []),
+        with start_span(
+            "vgrag.graph.insert_rebuilt",
+            {
+                "vgrag.entity_count": len(builder.entity_ids),
+                "vgrag.relation_count": len(builder.relation_ids),
+                "vgrag.passage_count": len(builder.passage_ids),
+            },
+        ):
+            entity_metadatas = []
+            for eid in builder.entity_ids:
+                entity_metadatas.append(
+                    {
+                        "relation_ids": builder.entity_to_relation_ids.get(eid, []),
+                        "passage_ids": builder.entity_to_passage_ids.get(eid, []),
+                    }
                 )
+
+            relation_metadatas = []
+            for rid in builder.relation_ids:
+                triplet = builder.relation_id_to_triplet.get(rid)
+                metadata = {
+                    "entity_ids": builder.relation_to_entity_ids.get(rid, []),
+                    "passage_ids": builder.relation_to_passage_ids.get(rid, []),
+                }
+                if triplet:
+                    metadata["subject"] = triplet.subject
+                    metadata["predicate"] = triplet.predicate
+                    metadata["object"] = triplet.object
+                relation_metadatas.append(metadata)
+
+            passage_metadatas = []
+            for pid in builder.passage_ids:
+                passage_metadatas.append(
+                    self._merge_passage_metadata(
+                        passage_user_metadatas.get(pid, {}),
+                        builder.passage_to_entity_ids.get(pid, []),
+                        builder.passage_to_relation_ids.get(pid, []),
+                    )
+                )
+
+            if show_progress:
+                logger.info("Inserting into Milvus...")
+
+            self._store._insert_entities(
+                builder.get_entity_texts(),
+                ids=builder.entity_ids,
+                embeddings=entity_embeddings,
+                metadatas=entity_metadatas,
+                show_progress=show_progress,
             )
-
-        if show_progress:
-            logger.info("Inserting into Milvus...")
-
-        self._store._insert_entities(
-            builder.get_entity_texts(),
-            ids=builder.entity_ids,
-            embeddings=entity_embeddings,
-            metadatas=entity_metadatas,
-            show_progress=show_progress,
-        )
-        self._store._insert_relations(
-            builder.get_relation_texts(),
-            ids=builder.relation_ids,
-            embeddings=relation_embeddings,
-            metadatas=relation_metadatas,
-            show_progress=show_progress,
-        )
-        self._store.insert_passages(
-            builder.get_passage_texts(),
-            ids=builder.passage_ids,
-            embeddings=passage_embeddings,
-            metadatas=passage_metadatas,
-            show_progress=show_progress,
-        )
+            self._store._insert_relations(
+                builder.get_relation_texts(),
+                ids=builder.relation_ids,
+                embeddings=relation_embeddings,
+                metadatas=relation_metadatas,
+                show_progress=show_progress,
+            )
+            self._store.insert_passages(
+                builder.get_passage_texts(),
+                ids=builder.passage_ids,
+                embeddings=passage_embeddings,
+                metadatas=passage_metadatas,
+                show_progress=show_progress,
+            )
 
     def _insert_incremental_graph(
         self,
@@ -708,26 +745,33 @@ class VectorGraphRAG:
         if not relation_ids:
             return [], []
 
-        # Query Milvus for relation data (using private method)
-        relation_data = self._store._get_relations_by_ids(relation_ids)
+        with start_span(
+            "vgrag.retrieve.passages_from_relations",
+            {
+                "vgrag.relation_count": len(relation_ids),
+                "vgrag.has_filter": bool(filter),
+            },
+        ):
+            # Query Milvus for relation data (using private method)
+            relation_data = self._store._get_relations_by_ids(relation_ids)
 
-        passage_ids: List[str] = []
-        seen_ids: set = set()
-        for rel in relation_data:
-            for pid in rel.get("passage_ids", []):
-                if pid not in seen_ids:
-                    seen_ids.add(pid)
-                    passage_ids.append(pid)
+            passage_ids: List[str] = []
+            seen_ids: set = set()
+            for rel in relation_data:
+                for pid in rel.get("passage_ids", []):
+                    if pid not in seen_ids:
+                        seen_ids.add(pid)
+                        passage_ids.append(pid)
 
-        if not passage_ids:
-            return [], []
+            if not passage_ids:
+                return [], []
 
-        passage_data = self._store.get_passages_by_ids(passage_ids, filter=filter)
-        id_to_text = {p["id"]: p["text"] for p in passage_data}
+            passage_data = self._store.get_passages_by_ids(passage_ids, filter=filter)
+            id_to_text = {p["id"]: p["text"] for p in passage_data}
 
-        passages = [id_to_text[pid] for pid in passage_ids if pid in id_to_text]
-        passage_ids = [pid for pid in passage_ids if pid in id_to_text]
-        return passage_ids, passages
+            passages = [id_to_text[pid] for pid in passage_ids if pid in id_to_text]
+            passage_ids = [pid for pid in passage_ids if pid in id_to_text]
+            return passage_ids, passages
 
     def add_texts(
         self,
@@ -816,15 +860,22 @@ class VectorGraphRAG:
             ...     "The theory of relativity changed physics forever.",
             ... ])
         """
-        documents = []
-        for i, text in enumerate(texts):
-            doc_id = ids[i] if ids and i < len(ids) else str(uuid.uuid4())
-            metadata = metadatas[i] if metadatas and i < len(metadatas) else {}
-            documents.append(Document(page_content=text, metadata=metadata, id=doc_id))
+        with self._observed_operation(
+            "vgrag.rebuild_texts",
+            {
+                "vgrag.text_count": len(texts),
+                "vgrag.extract_triplets": extract_triplets,
+            },
+        ):
+            documents = []
+            for i, text in enumerate(texts):
+                doc_id = ids[i] if ids and i < len(ids) else str(uuid.uuid4())
+                metadata = metadatas[i] if metadatas and i < len(metadatas) else {}
+                documents.append(Document(page_content=text, metadata=metadata, id=doc_id))
 
-        return self.rebuild_documents(
-            documents, extract_triplets=extract_triplets, show_progress=show_progress
-        )
+            return self.rebuild_documents(
+                documents, extract_triplets=extract_triplets, show_progress=show_progress
+            )
 
     def add_documents(
         self,
@@ -904,46 +955,53 @@ class VectorGraphRAG:
         Returns:
             ExtractionResult with graph statistics for the rebuilt graph.
         """
-        # Ensure all documents have IDs
-        for doc in documents:
-            if not doc.id:
-                doc.id = str(uuid.uuid4())
+        with self._observed_operation(
+            "vgrag.rebuild_documents",
+            {
+                "vgrag.document_count": len(documents),
+                "vgrag.extract_triplets": extract_triplets,
+            },
+        ):
+            # Ensure all documents have IDs
+            for doc in documents:
+                if not doc.id:
+                    doc.id = str(uuid.uuid4())
 
-        # Extract triplets if needed
-        if extract_triplets:
-            documents = self._triplet_extractor.extract_from_documents(
-                documents, show_progress=show_progress
+            # Extract triplets if needed
+            if extract_triplets:
+                documents = self._triplet_extractor.extract_from_documents(
+                    documents, show_progress=show_progress
+                )
+
+            (
+                self._extraction_result,
+                entity_embeddings,
+                relation_embeddings,
+                passage_embeddings,
+                passage_user_metadatas,
+            ) = self._build_graph_records(
+                self._graph_builder,
+                documents,
+                show_progress=show_progress,
             )
 
-        (
-            self._extraction_result,
-            entity_embeddings,
-            relation_embeddings,
-            passage_embeddings,
-            passage_user_metadatas,
-        ) = self._build_graph_records(
-            self._graph_builder,
-            documents,
-            show_progress=show_progress,
-        )
+            # Drop and recreate collections for fresh data
+            self._store.drop_collections()
+            self._store.create_collections(drop_existing=True)
 
-        # Drop and recreate collections for fresh data
-        self._store.drop_collections()
-        self._store.create_collections(drop_existing=True)
+            self._insert_rebuilt_graph(
+                self._graph_builder,
+                passage_user_metadatas,
+                entity_embeddings,
+                relation_embeddings,
+                passage_embeddings,
+                show_progress=show_progress,
+            )
 
-        self._insert_rebuilt_graph(
-            self._graph_builder,
-            passage_user_metadatas,
-            entity_embeddings,
-            relation_embeddings,
-            passage_embeddings,
-            show_progress=show_progress,
-        )
+            # Reset retriever to pick up new knowledge graph
+            self._retriever = None
 
-        # Reset retriever to pick up new knowledge graph
-        self._retriever = None
-
-        return self._extraction_result
+            return self._extraction_result
 
     def upsert_documents_by_source(
         self,
@@ -991,51 +1049,69 @@ class VectorGraphRAG:
             source_field=source_field,
             metadata=metadata,
         )
-        prepared_documents = self._prepare_upsert_documents(
-            resolved_source,
-            documents,
-            source_field=source_field,
-            metadata=metadata,
-        )
+        with self._observed_operation(
+            "vgrag.upsert_documents_by_source",
+            {
+                "vgrag.document_count": len(documents),
+                "vgrag.source_field": source_field,
+                "vgrag.extract_triplets": extract_triplets,
+            },
+            source=resolved_source,
+        ):
+            prepared_documents = self._prepare_upsert_documents(
+                resolved_source,
+                documents,
+                source_field=source_field,
+                metadata=metadata,
+            )
 
-        if extract_triplets:
-            prepared_documents = self._triplet_extractor.extract_from_documents(
+            if extract_triplets:
+                prepared_documents = self._triplet_extractor.extract_from_documents(
+                    prepared_documents,
+                    show_progress=show_progress,
+                )
+
+            builder = GraphBuilder(settings=self.settings)
+            (
+                result,
+                entity_embeddings,
+                relation_embeddings,
+                passage_embeddings,
+                passage_user_metadatas,
+            ) = self._build_graph_records(
+                builder,
                 prepared_documents,
                 show_progress=show_progress,
             )
 
-        builder = GraphBuilder(settings=self.settings)
-        (
-            result,
-            entity_embeddings,
-            relation_embeddings,
-            passage_embeddings,
-            passage_user_metadatas,
-        ) = self._build_graph_records(
-            builder,
-            prepared_documents,
-            show_progress=show_progress,
-        )
+            self.delete_documents_by_source(resolved_source, source_field=source_field)
+            with start_span(
+                "vgrag.graph.insert_incremental",
+                {
+                    "vgrag.source_field": source_field,
+                    "vgrag.entity_count": len(builder.entity_ids),
+                    "vgrag.relation_count": len(builder.relation_ids),
+                    "vgrag.passage_count": len(builder.passage_ids),
+                },
+            ):
+                entity_id_map, relation_id_map = self._insert_incremental_graph(
+                    builder,
+                    passage_user_metadatas,
+                    entity_embeddings,
+                    relation_embeddings,
+                    passage_embeddings,
+                    source=resolved_source,
+                    source_field=source_field,
+                    show_progress=show_progress,
+                )
 
-        self.delete_documents_by_source(resolved_source, source_field=source_field)
-        entity_id_map, relation_id_map = self._insert_incremental_graph(
-            builder,
-            passage_user_metadatas,
-            entity_embeddings,
-            relation_embeddings,
-            passage_embeddings,
-            source=resolved_source,
-            source_field=source_field,
-            show_progress=show_progress,
-        )
-
-        self._extraction_result = self._remap_extraction_result(
-            result,
-            entity_id_map=entity_id_map,
-            relation_id_map=relation_id_map,
-        )
-        self._retriever = None
-        return self._extraction_result
+            self._extraction_result = self._remap_extraction_result(
+                result,
+                entity_id_map=entity_id_map,
+                relation_id_map=relation_id_map,
+            )
+            self._retriever = None
+            return self._extraction_result
 
     def upsert_documents(self, *args: Any, **kwargs: Any) -> ExtractionResult:
         """
@@ -1072,87 +1148,98 @@ class VectorGraphRAG:
         source = self._normalize_source_value(source, "source")
         self._store._validate_field_name(source_field)
 
-        passages = self._store.get_passages_by_source(source, source_field=source_field)
-        if not passages:
-            return False
+        with self._observed_operation(
+            "vgrag.delete_documents_by_source",
+            {
+                "vgrag.source_field": source_field,
+            },
+            source=source,
+        ):
+            passages = self._store.get_passages_by_source(source, source_field=source_field)
+            if not passages:
+                return False
 
-        passage_ids = [passage["id"] for passage in passages]
-        removed_passage_ids = set(passage_ids)
+            passage_ids = [passage["id"] for passage in passages]
+            removed_passage_ids = set(passage_ids)
 
-        relation_ids = sorted(
-            {relation_id for passage in passages for relation_id in passage.get("relation_ids", [])}
-        )
-        entity_ids = sorted(
-            {entity_id for passage in passages for entity_id in passage.get("entity_ids", [])}
-        )
-
-        relations = self._store._get_relations_by_ids(relation_ids)
-        existing_relation_ids = {relation["id"] for relation in relations}
-        relation_update_records: List[Dict[str, Any]] = []
-        relation_delete_ids: List[str] = []
-        deleted_relation_ids: set[str] = set(relation_ids) - existing_relation_ids
-        for relation in relations:
-            relation_id = relation["id"]
-            new_passage_ids = self._remove_many(
-                relation.get("passage_ids", []),
-                removed_passage_ids,
-            )
-            if new_passage_ids:
-                update_record = {
-                    "id": relation_id,
-                    "text": relation["text"],
-                    "vector": self._embedding_model.embed(relation["text"]),
-                    "entity_ids": relation.get("entity_ids", []),
-                    "passage_ids": new_passage_ids,
+            relation_ids = sorted(
+                {
+                    relation_id
+                    for passage in passages
+                    for relation_id in passage.get("relation_ids", [])
                 }
-                for field in ["subject", "predicate", "object"]:
-                    if field in relation:
-                        update_record[field] = relation[field]
-                relation_update_records.append(update_record)
-            else:
-                relation_delete_ids.append(relation_id)
-                deleted_relation_ids.add(relation_id)
-
-        if relation_update_records:
-            self._store._upsert_relation_records(relation_update_records)
-        if relation_delete_ids:
-            self._store._delete_relations(relation_delete_ids)
-
-        entities = self._store._get_entities_by_ids(entity_ids)
-        entity_update_records: List[Dict[str, Any]] = []
-        entity_delete_ids: List[str] = []
-        for entity in entities:
-            entity_id = entity["id"]
-            new_passage_ids = self._remove_many(
-                entity.get("passage_ids", []),
-                removed_passage_ids,
             )
-            new_relation_ids = self._remove_many(
-                entity.get("relation_ids", []),
-                deleted_relation_ids,
+            entity_ids = sorted(
+                {entity_id for passage in passages for entity_id in passage.get("entity_ids", [])}
             )
 
-            if new_passage_ids or new_relation_ids:
-                entity_update_records.append(
-                    {
-                        "id": entity_id,
-                        "text": entity["text"],
-                        "vector": self._embedding_model.embed(entity["text"]),
-                        "passage_ids": new_passage_ids,
-                        "relation_ids": new_relation_ids,
-                    }
+            relations = self._store._get_relations_by_ids(relation_ids)
+            existing_relation_ids = {relation["id"] for relation in relations}
+            relation_update_records: List[Dict[str, Any]] = []
+            relation_delete_ids: List[str] = []
+            deleted_relation_ids: set[str] = set(relation_ids) - existing_relation_ids
+            for relation in relations:
+                relation_id = relation["id"]
+                new_passage_ids = self._remove_many(
+                    relation.get("passage_ids", []),
+                    removed_passage_ids,
                 )
-            else:
-                entity_delete_ids.append(entity_id)
+                if new_passage_ids:
+                    update_record = {
+                        "id": relation_id,
+                        "text": relation["text"],
+                        "vector": self._embedding_model.embed(relation["text"]),
+                        "entity_ids": relation.get("entity_ids", []),
+                        "passage_ids": new_passage_ids,
+                    }
+                    for field in ["subject", "predicate", "object"]:
+                        if field in relation:
+                            update_record[field] = relation[field]
+                    relation_update_records.append(update_record)
+                else:
+                    relation_delete_ids.append(relation_id)
+                    deleted_relation_ids.add(relation_id)
 
-        if entity_update_records:
-            self._store._upsert_entity_records(entity_update_records)
-        if entity_delete_ids:
-            self._store._delete_entities(entity_delete_ids)
+            if relation_update_records:
+                self._store._upsert_relation_records(relation_update_records)
+            if relation_delete_ids:
+                self._store._delete_relations(relation_delete_ids)
 
-        self._store.delete_passages(passage_ids)
-        self._retriever = None
-        return True
+            entities = self._store._get_entities_by_ids(entity_ids)
+            entity_update_records: List[Dict[str, Any]] = []
+            entity_delete_ids: List[str] = []
+            for entity in entities:
+                entity_id = entity["id"]
+                new_passage_ids = self._remove_many(
+                    entity.get("passage_ids", []),
+                    removed_passage_ids,
+                )
+                new_relation_ids = self._remove_many(
+                    entity.get("relation_ids", []),
+                    deleted_relation_ids,
+                )
+
+                if new_passage_ids or new_relation_ids:
+                    entity_update_records.append(
+                        {
+                            "id": entity_id,
+                            "text": entity["text"],
+                            "vector": self._embedding_model.embed(entity["text"]),
+                            "passage_ids": new_passage_ids,
+                            "relation_ids": new_relation_ids,
+                        }
+                    )
+                else:
+                    entity_delete_ids.append(entity_id)
+
+            if entity_update_records:
+                self._store._upsert_entity_records(entity_update_records)
+            if entity_delete_ids:
+                self._store._delete_entities(entity_delete_ids)
+
+            self._store.delete_passages(passage_ids)
+            self._retriever = None
+            return True
 
     def delete_documents(self, *args: Any, **kwargs: Any) -> bool:
         """
@@ -1246,25 +1333,32 @@ class VectorGraphRAG:
             ...     },
             ... ])
         """
-        docs = []
-        for doc_data in documents:
-            passage = doc_data.get("passage", doc_data.get("text"))
-            if passage is None:
-                raise ValueError('Each document must include "passage" or "text".')
-            doc_id = doc_data.get("id") or str(uuid.uuid4())
-            # Store triplets in metadata as list of [subject, predicate, object]
-            triplets = doc_data.get("triplets", [])
-            metadata = dict(doc_data.get("metadata") or {})
-            metadata["triplets"] = triplets
-            docs.append(
-                Document(
-                    page_content=passage,
-                    metadata=metadata,
-                    id=doc_id,
+        with self._observed_operation(
+            "vgrag.rebuild_documents_with_triplets",
+            {
+                "vgrag.document_count": len(documents),
+                "vgrag.extract_triplets": False,
+            },
+        ):
+            docs = []
+            for doc_data in documents:
+                passage = doc_data.get("passage", doc_data.get("text"))
+                if passage is None:
+                    raise ValueError('Each document must include "passage" or "text".')
+                doc_id = doc_data.get("id") or str(uuid.uuid4())
+                # Store triplets in metadata as list of [subject, predicate, object]
+                triplets = doc_data.get("triplets", [])
+                metadata = dict(doc_data.get("metadata") or {})
+                metadata["triplets"] = triplets
+                docs.append(
+                    Document(
+                        page_content=passage,
+                        metadata=metadata,
+                        id=doc_id,
+                    )
                 )
-            )
 
-        return self.rebuild_documents(docs, extract_triplets=False, show_progress=show_progress)
+            return self.rebuild_documents(docs, extract_triplets=False, show_progress=show_progress)
 
     def query(
         self,
@@ -1308,75 +1402,84 @@ class VectorGraphRAG:
             >>> print(result.answer)
             >>> print(result.subgraph.expansion_history)  # Visualize expansion
         """
-        retriever = self._ensure_retriever()
+        with self._observed_operation(
+            "vgrag.query",
+            {
+                "vgrag.use_reranking": use_reranking,
+                "vgrag.compare_naive": compare_naive,
+                "vgrag.has_filter": bool(filter),
+                "vgrag.question_length": len(question),
+            },
+        ):
+            retriever = self._ensure_retriever()
 
-        # Retrieve with custom parameters
-        retrieval_result = retriever.retrieve(
-            question,
-            entity_top_k=entity_top_k,
-            relation_top_k=relation_top_k,
-            entity_similarity_threshold=entity_similarity_threshold,
-            relation_similarity_threshold=relation_similarity_threshold,
-            expansion_degree=expansion_degree,
-            filter=filter,
-        )
-
-        # Build retrieval detail for visualization
-        retrieval_detail = RetrievalDetail(
-            entity_ids=retrieval_result.entity_ids,
-            entity_texts=retrieval_result.entity_texts,
-            entity_scores=retrieval_result.entity_scores,
-            relation_ids=retrieval_result.relation_ids,
-            relation_texts=retrieval_result.relation_texts,
-            relation_scores=retrieval_result.relation_scores,
-        )
-
-        # Get candidate relations from subgraph
-        candidate_ids = retrieval_result.expanded_relation_ids
-        candidate_texts = retrieval_result.expanded_relation_texts
-
-        # Rerank if enabled
-        rerank_result = None
-        if use_reranking and candidate_ids:
-            reranked_ids, reranked_texts = self._reranker.rerank(
-                question, candidate_ids, candidate_texts
+            # Retrieve with custom parameters
+            retrieval_result = retriever.retrieve(
+                question,
+                entity_top_k=entity_top_k,
+                relation_top_k=relation_top_k,
+                entity_similarity_threshold=entity_similarity_threshold,
+                relation_similarity_threshold=relation_similarity_threshold,
+                expansion_degree=expansion_degree,
+                filter=filter,
             )
-            rerank_result = RerankResult(
-                selected_relation_ids=reranked_ids,
-                selected_relation_texts=reranked_texts,
+
+            # Build retrieval detail for visualization
+            retrieval_detail = RetrievalDetail(
+                entity_ids=retrieval_result.entity_ids,
+                entity_texts=retrieval_result.entity_texts,
+                entity_scores=retrieval_result.entity_scores,
+                relation_ids=retrieval_result.relation_ids,
+                relation_texts=retrieval_result.relation_texts,
+                relation_scores=retrieval_result.relation_scores,
             )
-        else:
-            reranked_ids = candidate_ids[: self.settings.final_top_k]
-            reranked_texts = candidate_texts[: self.settings.final_top_k]
 
-        # Get passages from reranked relations
-        passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
-        final_passages = passages[: self.settings.final_top_k]
+            # Get candidate relations from subgraph
+            candidate_ids = retrieval_result.expanded_relation_ids
+            candidate_texts = retrieval_result.expanded_relation_texts
 
-        # Generate answer
-        answer = self._answer_generator.generate(question, final_passages)
+            # Rerank if enabled
+            rerank_result = None
+            if use_reranking and candidate_ids:
+                reranked_ids, reranked_texts = self._reranker.rerank(
+                    question, candidate_ids, candidate_texts
+                )
+                rerank_result = RerankResult(
+                    selected_relation_ids=reranked_ids,
+                    selected_relation_texts=reranked_texts,
+                )
+            else:
+                reranked_ids = candidate_ids[: self.settings.final_top_k]
+                reranked_texts = candidate_texts[: self.settings.final_top_k]
 
-        # Build eviction result
-        eviction_result = EvictionResult(
-            occurred=retrieval_result.eviction_occurred,
-            before_count=retrieval_result.eviction_before_count,
-            after_count=retrieval_result.eviction_after_count,
-        )
+            # Get passages from reranked relations
+            passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
+            final_passages = passages[: self.settings.final_top_k]
 
-        return QueryResult(
-            query=question,
-            answer=answer,
-            query_entities=retrieval_result.query_entities,
-            retrieved_passages=final_passages,
-            retrieved_relations=retrieval_result.relation_texts,
-            expanded_relations=candidate_texts,
-            reranked_relations=reranked_texts,
-            subgraph=retrieval_result.subgraph,
-            passages=final_passages,
-            retrieval_detail=retrieval_detail,
-            rerank_result=rerank_result,
-            eviction_result=eviction_result,
-        )
+            # Generate answer
+            answer = self._answer_generator.generate(question, final_passages)
+
+            # Build eviction result
+            eviction_result = EvictionResult(
+                occurred=retrieval_result.eviction_occurred,
+                before_count=retrieval_result.eviction_before_count,
+                after_count=retrieval_result.eviction_after_count,
+            )
+
+            return QueryResult(
+                query=question,
+                answer=answer,
+                query_entities=retrieval_result.query_entities,
+                retrieved_passages=final_passages,
+                retrieved_relations=retrieval_result.relation_texts,
+                expanded_relations=candidate_texts,
+                reranked_relations=reranked_texts,
+                subgraph=retrieval_result.subgraph,
+                passages=final_passages,
+                retrieval_detail=retrieval_detail,
+                rerank_result=rerank_result,
+                eviction_result=eviction_result,
+            )
 
     def query_simple(self, question: str, filter: Optional[str] = None) -> str:
         """
@@ -1408,18 +1511,25 @@ class VectorGraphRAG:
         Returns:
             QueryResult with answer and retrieved passages.
         """
-        retriever = self._ensure_retriever()
-        passages = retriever.retrieve_passages_naive(question, filter=filter)
-        answer = self._answer_generator.generate(question, passages)
+        with self._observed_operation(
+            "vgrag.query_naive",
+            {
+                "vgrag.has_filter": bool(filter),
+                "vgrag.question_length": len(question),
+            },
+        ):
+            retriever = self._ensure_retriever()
+            passages = retriever.retrieve_passages_naive(question, filter=filter)
+            answer = self._answer_generator.generate(question, passages)
 
-        return QueryResult(
-            query=question,
-            answer=answer,
-            retrieved_passages=passages,
-            retrieved_relations=[],
-            expanded_relations=[],
-            reranked_relations=[],
-        )
+            return QueryResult(
+                query=question,
+                answer=answer,
+                retrieved_passages=passages,
+                retrieved_relations=[],
+                expanded_relations=[],
+                reranked_relations=[],
+            )
 
     def retrieve(
         self,
@@ -1443,49 +1553,57 @@ class VectorGraphRAG:
         Returns:
             QueryResult with retrieved passages (answer will be empty).
         """
-        retriever = self._ensure_retriever()
-        top_k = top_k or self.settings.final_top_k
+        with self._observed_operation(
+            "vgrag.retrieve",
+            {
+                "vgrag.use_reranking": use_reranking,
+                "vgrag.has_filter": bool(filter),
+                "vgrag.question_length": len(question),
+            },
+        ):
+            retriever = self._ensure_retriever()
+            top_k = top_k or self.settings.final_top_k
 
-        # Retrieve
-        retrieval_result = retriever.retrieve(question, filter=filter)
+            # Retrieve
+            retrieval_result = retriever.retrieve(question, filter=filter)
 
-        # Get candidate relations
-        candidate_ids = retrieval_result.expanded_relation_ids
-        candidate_texts = retrieval_result.expanded_relation_texts
+            # Get candidate relations
+            candidate_ids = retrieval_result.expanded_relation_ids
+            candidate_texts = retrieval_result.expanded_relation_texts
 
-        # Rerank if enabled
-        if use_reranking and candidate_ids:
-            reranked_ids, reranked_texts = self._reranker.rerank(
-                question, candidate_ids, candidate_texts
+            # Rerank if enabled
+            if use_reranking and candidate_ids:
+                reranked_ids, reranked_texts = self._reranker.rerank(
+                    question, candidate_ids, candidate_texts
+                )
+            else:
+                reranked_ids = candidate_ids[:top_k]
+                reranked_texts = candidate_texts[:top_k]
+
+            # Get passages from reranked relations
+            passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
+
+            if len(passages) < top_k:
+                additional_passages = retriever.retrieve_passages_naive(
+                    question,
+                    top_k=top_k,
+                    filter=filter,
+                )
+                for passage in additional_passages:
+                    if passage not in passages:
+                        passages.append(passage)
+                        if len(passages) >= top_k:
+                            break
+            final_passages = passages[:top_k]
+
+            return QueryResult(
+                query=question,
+                answer="",  # No answer generation
+                retrieved_passages=final_passages,
+                retrieved_relations=retrieval_result.relation_texts,
+                expanded_relations=candidate_texts,
+                reranked_relations=reranked_texts,
             )
-        else:
-            reranked_ids = candidate_ids[:top_k]
-            reranked_texts = candidate_texts[:top_k]
-
-        # Get passages from reranked relations
-        passage_ids, passages = self._get_passages_from_relations(reranked_ids, filter=filter)
-
-        if len(passages) < top_k:
-            additional_passages = retriever.retrieve_passages_naive(
-                question,
-                top_k=top_k,
-                filter=filter,
-            )
-            for passage in additional_passages:
-                if passage not in passages:
-                    passages.append(passage)
-                    if len(passages) >= top_k:
-                        break
-        final_passages = passages[:top_k]
-
-        return QueryResult(
-            query=question,
-            answer="",  # No answer generation
-            retrieved_passages=final_passages,
-            retrieved_relations=retrieval_result.relation_texts,
-            expanded_relations=candidate_texts,
-            reranked_relations=reranked_texts,
-        )
 
     def retrieve_naive(
         self,
@@ -1507,18 +1625,25 @@ class VectorGraphRAG:
         Returns:
             QueryResult with retrieved passages (answer will be empty).
         """
-        retriever = self._ensure_retriever()
-        top_k = top_k or self.settings.final_top_k
-        passages = retriever.retrieve_passages_naive(question, top_k=top_k, filter=filter)
+        with self._observed_operation(
+            "vgrag.retrieve_naive",
+            {
+                "vgrag.has_filter": bool(filter),
+                "vgrag.question_length": len(question),
+            },
+        ):
+            retriever = self._ensure_retriever()
+            top_k = top_k or self.settings.final_top_k
+            passages = retriever.retrieve_passages_naive(question, top_k=top_k, filter=filter)
 
-        return QueryResult(
-            query=question,
-            answer="",  # No answer generation
-            retrieved_passages=passages,
-            retrieved_relations=[],
-            expanded_relations=[],
-            reranked_relations=[],
-        )
+            return QueryResult(
+                query=question,
+                answer="",  # No answer generation
+                retrieved_passages=passages,
+                retrieved_relations=[],
+                expanded_relations=[],
+                reranked_relations=[],
+            )
 
     def get_stats(self) -> dict:
         """

--- a/src/vector_graph_rag/storage/embeddings.py
+++ b/src/vector_graph_rag/storage/embeddings.py
@@ -8,6 +8,7 @@ from typing import List, Literal, Optional
 from tqdm import tqdm
 
 from vector_graph_rag.config import Settings, get_settings
+from vector_graph_rag.observability import start_span
 from vector_graph_rag.storage.embedding_providers import (
     DEFAULT_MODELS,
     canonicalize_provider,
@@ -171,8 +172,18 @@ class EmbeddingModel:
         Returns:
             Embedding vector as a list of floats.
         """
-        embeddings = self._backend.encode(text, text_type=text_type)
-        return embeddings[0].tolist()
+        with start_span(
+            "vgrag.embedding.embed",
+            {
+                "vgrag.embedding_provider": self.provider_name,
+                "vgrag.embedding_model": self.model_name,
+                "vgrag.text_type": text_type,
+                "vgrag.text_count": 1,
+                "vgrag.text_length": len(text),
+            },
+        ):
+            embeddings = self._backend.encode(text, text_type=text_type)
+            return embeddings[0].tolist()
 
     def embed_batch(
         self,
@@ -200,11 +211,22 @@ class EmbeddingModel:
         all_embeddings = []
 
         batches = [texts[i : i + batch_size] for i in range(0, len(texts), batch_size)]
-        iterator = tqdm(batches, desc="Generating embeddings") if show_progress else batches
+        with start_span(
+            "vgrag.embedding.batch",
+            {
+                "vgrag.embedding_provider": self.provider_name,
+                "vgrag.embedding_model": self.model_name,
+                "vgrag.text_type": text_type,
+                "vgrag.text_count": len(texts),
+                "vgrag.batch_size": batch_size,
+                "vgrag.batch_count": len(batches),
+            },
+        ):
+            iterator = tqdm(batches, desc="Generating embeddings") if show_progress else batches
 
-        for batch in iterator:
-            embeddings = self._backend.encode(batch, text_type=text_type)
-            all_embeddings.extend(embeddings.tolist())
+            for batch in iterator:
+                embeddings = self._backend.encode(batch, text_type=text_type)
+                all_embeddings.extend(embeddings.tolist())
 
         return all_embeddings
 

--- a/src/vector_graph_rag/storage/milvus.py
+++ b/src/vector_graph_rag/storage/milvus.py
@@ -19,6 +19,7 @@ from pymilvus import DataType, MilvusClient
 from tqdm import tqdm
 
 from vector_graph_rag.config import Settings, get_settings
+from vector_graph_rag.observability import start_span
 from vector_graph_rag.storage.embeddings import EmbeddingModel
 
 logger = logging.getLogger(__name__)
@@ -131,17 +132,27 @@ class MilvusStore:
         if not unique_texts:
             return records_by_text
 
-        for batch_texts in self._batch_items(unique_texts):
-            quoted_texts = ", ".join(self._quote_string(text) for text in batch_texts)
-            results = self.client.query(
-                collection_name=collection_name,
-                filter=f"text in [{quoted_texts}]",
-                output_fields=output_fields,
-            )
-            for record in results:
-                text = record.get("text")
-                if isinstance(text, str) and text not in records_by_text:
-                    records_by_text[text] = record
+        with start_span(
+            "vgrag.milvus.query_by_texts",
+            {
+                "db.system": "milvus",
+                "db.collection.name": collection_name,
+                "vgrag.record_count": len(texts),
+                "vgrag.unique_record_count": len(unique_texts),
+                "vgrag.batch_size": self.settings.batch_size,
+            },
+        ):
+            for batch_texts in self._batch_items(unique_texts):
+                quoted_texts = ", ".join(self._quote_string(text) for text in batch_texts)
+                results = self.client.query(
+                    collection_name=collection_name,
+                    filter=f"text in [{quoted_texts}]",
+                    output_fields=output_fields,
+                )
+                for record in results:
+                    text = record.get("text")
+                    if isinstance(text, str) and text not in records_by_text:
+                        records_by_text[text] = record
 
         return records_by_text
 
@@ -154,11 +165,20 @@ class MilvusStore:
         if not records:
             return
 
-        for batch_records in self._batch_items(records):
-            self.client.upsert(
-                collection_name=collection_name,
-                data=batch_records,
-            )
+        with start_span(
+            "vgrag.milvus.upsert",
+            {
+                "db.system": "milvus",
+                "db.collection.name": collection_name,
+                "vgrag.record_count": len(records),
+                "vgrag.batch_size": self.settings.batch_size,
+            },
+        ):
+            for batch_records in self._batch_items(records):
+                self.client.upsert(
+                    collection_name=collection_name,
+                    data=batch_records,
+                )
 
     def _upsert_entity_records(self, records: List[Dict[str, Any]]) -> None:
         """Upsert fully materialized entity records."""
@@ -204,13 +224,23 @@ class MilvusStore:
             add_index_kwargs["params"] = index_params_config
         index_params.add_index(**add_index_kwargs)
 
-        self.client.create_collection(
-            collection_name=collection_name,
-            schema=schema,
-            index_params=index_params,
-            # consistency_level="Strong",  # Strong waits for all loads to complete
-            consistency_level=self.settings.milvus_consistency_level,
-        )
+        with start_span(
+            "vgrag.milvus.create_collection",
+            {
+                "db.system": "milvus",
+                "db.collection.name": collection_name,
+                "vgrag.embedding_dimension": dim,
+                "vgrag.milvus_index_type": index_type,
+                "vgrag.milvus_consistency_level": self.settings.milvus_consistency_level,
+            },
+        ):
+            self.client.create_collection(
+                collection_name=collection_name,
+                schema=schema,
+                index_params=index_params,
+                # consistency_level="Strong",  # Strong waits for all loads to complete
+                consistency_level=self.settings.milvus_consistency_level,
+            )
 
     def create_collections(
         self,
@@ -237,13 +267,20 @@ class MilvusStore:
 
     def drop_collections(self) -> None:
         """Drop all collections."""
-        for collection_name in [
-            self.entity_collection,
-            self.relation_collection,
-            self.passage_collection,
-        ]:
-            if self.client.has_collection(collection_name):
-                self.client.drop_collection(collection_name)
+        with start_span(
+            "vgrag.milvus.drop_collections",
+            {
+                "db.system": "milvus",
+                "vgrag.collection_count": 3,
+            },
+        ):
+            for collection_name in [
+                self.entity_collection,
+                self.relation_collection,
+                self.passage_collection,
+            ]:
+                if self.client.has_collection(collection_name):
+                    self.client.drop_collection(collection_name)
 
     def _insert_data(
         self,
@@ -274,24 +311,34 @@ class MilvusStore:
         if show_progress:
             iterator = tqdm(iterator, total=total_batches, desc=f"Inserting to {collection_name}")
 
-        for start_idx in iterator:
-            end_idx = min(start_idx + batch_size, len(ids))
-            batch_data = [
-                {
-                    "id": ids[i],
-                    "text": texts[i],
-                    "vector": embeddings[i],
-                }
-                for i in range(start_idx, end_idx)
-            ]
-            # Add metadata if provided
-            if metadatas:
-                for i, data in enumerate(batch_data):
-                    idx = start_idx + i
-                    if idx < len(metadatas):
-                        data.update(metadatas[idx])
+        with start_span(
+            "vgrag.milvus.insert",
+            {
+                "db.system": "milvus",
+                "db.collection.name": collection_name,
+                "vgrag.record_count": len(ids),
+                "vgrag.batch_size": batch_size,
+                "vgrag.batch_count": total_batches,
+            },
+        ):
+            for start_idx in iterator:
+                end_idx = min(start_idx + batch_size, len(ids))
+                batch_data = [
+                    {
+                        "id": ids[i],
+                        "text": texts[i],
+                        "vector": embeddings[i],
+                    }
+                    for i in range(start_idx, end_idx)
+                ]
+                # Add metadata if provided
+                if metadatas:
+                    for i, data in enumerate(batch_data):
+                        idx = start_idx + i
+                        if idx < len(metadatas):
+                            data.update(metadatas[idx])
 
-            self.client.insert(collection_name=collection_name, data=batch_data)
+                self.client.insert(collection_name=collection_name, data=batch_data)
 
     def _insert_entities(
         self,
@@ -456,12 +503,22 @@ class MilvusStore:
         """
         top_k = top_k or self.settings.entity_top_k
 
-        results = self.client.search(
-            collection_name=self.entity_collection,
-            data=query_embeddings,
-            limit=top_k,
-            output_fields=["id", "text", "relation_ids", "passage_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.search",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.entity_collection,
+                "vgrag.query_vector_count": len(query_embeddings),
+                "vgrag.top_k": top_k,
+                "vgrag.record_type": "entity",
+            },
+        ):
+            results = self.client.search(
+                collection_name=self.entity_collection,
+                data=query_embeddings,
+                limit=top_k,
+                output_fields=["id", "text", "relation_ids", "passage_ids"],
+            )
         return results
 
     def _search_relations(
@@ -485,20 +542,30 @@ class MilvusStore:
         """
         top_k = top_k or self.settings.relation_top_k
 
-        results = self.client.search(
-            collection_name=self.relation_collection,
-            data=[query_embedding],
-            limit=top_k,
-            output_fields=[
-                "id",
-                "text",
-                "entity_ids",
-                "passage_ids",
-                "subject",
-                "predicate",
-                "object",
-            ],
-        )
+        with start_span(
+            "vgrag.milvus.search",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.relation_collection,
+                "vgrag.query_vector_count": 1,
+                "vgrag.top_k": top_k,
+                "vgrag.record_type": "relation",
+            },
+        ):
+            results = self.client.search(
+                collection_name=self.relation_collection,
+                data=[query_embedding],
+                limit=top_k,
+                output_fields=[
+                    "id",
+                    "text",
+                    "entity_ids",
+                    "passage_ids",
+                    "subject",
+                    "predicate",
+                    "object",
+                ],
+            )
         return results[0] if results else []
 
     def search_passages(
@@ -520,13 +587,24 @@ class MilvusStore:
         """
         top_k = top_k or self.settings.final_top_k
 
-        results = self.client.search(
-            collection_name=self.passage_collection,
-            data=[query_embedding],
-            limit=top_k,
-            filter=filter,
-            output_fields=["id", "text", "entity_ids", "relation_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.search",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.query_vector_count": 1,
+                "vgrag.top_k": top_k,
+                "vgrag.record_type": "passage",
+                "vgrag.has_filter": bool(filter),
+            },
+        ):
+            results = self.client.search(
+                collection_name=self.passage_collection,
+                data=[query_embedding],
+                limit=top_k,
+                filter=filter,
+                output_fields=["id", "text", "entity_ids", "relation_ids"],
+            )
         return results[0] if results else []
 
     def _get_entities_by_ids(
@@ -549,11 +627,20 @@ class MilvusStore:
 
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{eid}"' for eid in entity_ids)
-        results = self.client.query(
-            collection_name=self.entity_collection,
-            filter=f"id in [{ids_str}]",
-            output_fields=["id", "text", "relation_ids", "passage_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.entity_collection,
+                "vgrag.record_type": "entity",
+                "vgrag.id_count": len(entity_ids),
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.entity_collection,
+                filter=f"id in [{ids_str}]",
+                output_fields=["id", "text", "relation_ids", "passage_ids"],
+            )
         return results
 
     def _get_entities_by_texts(
@@ -598,19 +685,28 @@ class MilvusStore:
 
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{rid}"' for rid in relation_ids)
-        results = self.client.query(
-            collection_name=self.relation_collection,
-            filter=f"id in [{ids_str}]",
-            output_fields=[
-                "id",
-                "text",
-                "entity_ids",
-                "passage_ids",
-                "subject",
-                "predicate",
-                "object",
-            ],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.relation_collection,
+                "vgrag.record_type": "relation",
+                "vgrag.id_count": len(relation_ids),
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.relation_collection,
+                filter=f"id in [{ids_str}]",
+                output_fields=[
+                    "id",
+                    "text",
+                    "entity_ids",
+                    "passage_ids",
+                    "subject",
+                    "predicate",
+                    "object",
+                ],
+            )
         return results
 
     def _get_relations_by_texts(
@@ -665,11 +761,21 @@ class MilvusStore:
         # Format IDs as quoted strings for Milvus filter
         ids_str = ", ".join(f'"{pid}"' for pid in passage_ids)
         filter_expr = self._combine_filters(f"id in [{ids_str}]", filter)
-        results = self.client.query(
-            collection_name=self.passage_collection,
-            filter=filter_expr,
-            output_fields=output_fields or ["id", "text", "entity_ids", "relation_ids"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.id_count": len(passage_ids),
+                "vgrag.has_filter": bool(filter),
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.passage_collection,
+                filter=filter_expr,
+                output_fields=output_fields or ["id", "text", "entity_ids", "relation_ids"],
+            )
         return list(results)
 
     def get_passages_by_document_id(self, document_id: str) -> List[Dict[str, Any]]:
@@ -685,11 +791,20 @@ class MilvusStore:
         Returns:
             Matching passage records with graph adjacency metadata.
         """
-        results = self.client.query(
-            collection_name=self.passage_collection,
-            filter=f"document_id == {self._quote_string(document_id)}",
-            output_fields=["id", "text", "entity_ids", "relation_ids", "document_id"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.lookup_field": "document_id",
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.passage_collection,
+                filter=f"document_id == {self._quote_string(document_id)}",
+                output_fields=["id", "text", "entity_ids", "relation_ids", "document_id"],
+            )
         return list(results)
 
     def get_passages_by_source(
@@ -708,11 +823,20 @@ class MilvusStore:
             Matching passage records with graph adjacency metadata.
         """
         source_field = self._validate_field_name(source_field)
-        results = self.client.query(
-            collection_name=self.passage_collection,
-            filter=f"{source_field} == {self._quote_string(source)}",
-            output_fields=["id", "text", "entity_ids", "relation_ids", source_field],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.lookup_field": source_field,
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.passage_collection,
+                filter=f"{source_field} == {self._quote_string(source)}",
+                output_fields=["id", "text", "entity_ids", "relation_ids", source_field],
+            )
         return list(results)
 
     def query_passage_ids(self, filter: str) -> List[str]:
@@ -728,11 +852,20 @@ class MilvusStore:
         if not filter or not filter.strip():
             return []
 
-        results = self.client.query(
-            collection_name=self.passage_collection,
-            filter=filter,
-            output_fields=["id"],
-        )
+        with start_span(
+            "vgrag.milvus.query",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.has_filter": True,
+            },
+        ):
+            results = self.client.query(
+                collection_name=self.passage_collection,
+                filter=filter,
+                output_fields=["id"],
+            )
         return [r["id"] for r in results]
 
     # ==================== Update Operations ====================
@@ -796,10 +929,19 @@ class MilvusStore:
             update_data["passage_ids"] = entity_data["passage_ids"]
 
         # Upsert the entity
-        self.client.upsert(
-            collection_name=self.entity_collection,
-            data=[update_data],
-        )
+        with start_span(
+            "vgrag.milvus.upsert",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.entity_collection,
+                "vgrag.record_type": "entity",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.upsert(
+                collection_name=self.entity_collection,
+                data=[update_data],
+            )
         return True
 
     def _update_relation(
@@ -877,10 +1019,19 @@ class MilvusStore:
         elif "object" in relation_data:
             update_data["object"] = relation_data["object"]
 
-        self.client.upsert(
-            collection_name=self.relation_collection,
-            data=[update_data],
-        )
+        with start_span(
+            "vgrag.milvus.upsert",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.relation_collection,
+                "vgrag.record_type": "relation",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.upsert(
+                collection_name=self.relation_collection,
+                data=[update_data],
+            )
         return True
 
     def update_passage(
@@ -935,10 +1086,19 @@ class MilvusStore:
         elif "relation_ids" in passage_data:
             update_data["relation_ids"] = passage_data["relation_ids"]
 
-        self.client.upsert(
-            collection_name=self.passage_collection,
-            data=[update_data],
-        )
+        with start_span(
+            "vgrag.milvus.upsert",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.upsert(
+                collection_name=self.passage_collection,
+                data=[update_data],
+            )
         return True
 
     # ==================== Delete Operations ====================
@@ -959,10 +1119,19 @@ class MilvusStore:
         if not existing:
             return False
 
-        self.client.delete(
-            collection_name=self.entity_collection,
-            filter=f'id == "{entity_id}"',
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.entity_collection,
+                "vgrag.record_type": "entity",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.delete(
+                collection_name=self.entity_collection,
+                filter=f'id == "{entity_id}"',
+            )
         return True
 
     def _delete_relation(self, relation_id: str) -> bool:
@@ -981,10 +1150,19 @@ class MilvusStore:
         if not existing:
             return False
 
-        self.client.delete(
-            collection_name=self.relation_collection,
-            filter=f'id == "{relation_id}"',
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.relation_collection,
+                "vgrag.record_type": "relation",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.delete(
+                collection_name=self.relation_collection,
+                filter=f'id == "{relation_id}"',
+            )
         return True
 
     def delete_passage(self, passage_id: str) -> bool:
@@ -1001,10 +1179,19 @@ class MilvusStore:
         if not existing:
             return False
 
-        self.client.delete(
-            collection_name=self.passage_collection,
-            filter=f'id == "{passage_id}"',
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.record_count": 1,
+            },
+        ):
+            self.client.delete(
+                collection_name=self.passage_collection,
+                filter=f'id == "{passage_id}"',
+            )
         return True
 
     def _delete_entities(self, entity_ids: List[str]) -> int:
@@ -1023,10 +1210,19 @@ class MilvusStore:
             return 0
 
         ids_str = ", ".join(f'"{eid}"' for eid in entity_ids)
-        self.client.delete(
-            collection_name=self.entity_collection,
-            filter=f"id in [{ids_str}]",
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.entity_collection,
+                "vgrag.record_type": "entity",
+                "vgrag.record_count": len(entity_ids),
+            },
+        ):
+            self.client.delete(
+                collection_name=self.entity_collection,
+                filter=f"id in [{ids_str}]",
+            )
         return len(entity_ids)
 
     def _delete_relations(self, relation_ids: List[str]) -> int:
@@ -1045,10 +1241,19 @@ class MilvusStore:
             return 0
 
         ids_str = ", ".join(f'"{rid}"' for rid in relation_ids)
-        self.client.delete(
-            collection_name=self.relation_collection,
-            filter=f"id in [{ids_str}]",
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.relation_collection,
+                "vgrag.record_type": "relation",
+                "vgrag.record_count": len(relation_ids),
+            },
+        ):
+            self.client.delete(
+                collection_name=self.relation_collection,
+                filter=f"id in [{ids_str}]",
+            )
         return len(relation_ids)
 
     def delete_passages(self, passage_ids: List[str]) -> int:
@@ -1065,10 +1270,19 @@ class MilvusStore:
             return 0
 
         ids_str = ", ".join(f'"{pid}"' for pid in passage_ids)
-        self.client.delete(
-            collection_name=self.passage_collection,
-            filter=f"id in [{ids_str}]",
-        )
+        with start_span(
+            "vgrag.milvus.delete",
+            {
+                "db.system": "milvus",
+                "db.collection.name": self.passage_collection,
+                "vgrag.record_type": "passage",
+                "vgrag.record_count": len(passage_ids),
+            },
+        ):
+            self.client.delete(
+                collection_name=self.passage_collection,
+                filter=f"id in [{ids_str}]",
+            )
         return len(passage_ids)
 
     # ==================== Utility Methods ====================
@@ -1119,7 +1333,13 @@ class MilvusStore:
         client = MilvusClient(**client_kwargs)
 
         # List all collections
-        all_collections = client.list_collections()
+        with start_span(
+            "vgrag.milvus.list_collections",
+            {
+                "db.system": "milvus",
+            },
+        ):
+            all_collections = client.list_collections()
 
         # Find entity collections and extract prefixes
         graphs: List[Dict[str, Any]] = []
@@ -1195,14 +1415,22 @@ class MilvusStore:
         deleted = False
 
         # Delete each collection if it exists
-        for collection_name in [entity_col, relation_col, passage_col]:
-            try:
-                if client.has_collection(collection_name):
-                    client.drop_collection(collection_name)
-                    deleted = True
-            except Exception as e:
-                # Log error but continue with other collections
-                logger.error("Error deleting collection %s: %s", collection_name, e)
+        with start_span(
+            "vgrag.milvus.delete_graph",
+            {
+                "db.system": "milvus",
+                "vgrag.graph_name": graph_name,
+                "vgrag.collection_count": 3,
+            },
+        ):
+            for collection_name in [entity_col, relation_col, passage_col]:
+                try:
+                    if client.has_collection(collection_name):
+                        client.drop_collection(collection_name)
+                        deleted = True
+                except Exception as e:
+                    # Log error but continue with other collections
+                    logger.error("Error deleting collection %s: %s", collection_name, e)
 
         return deleted
 
@@ -1219,25 +1447,32 @@ class MilvusStore:
             "passage_count": 0,
         }
 
-        try:
-            if self.client.has_collection(self.entity_collection):
-                entity_stats = self.client.get_collection_stats(self.entity_collection)
-                stats["entity_count"] = entity_stats.get("row_count", 0)
-        except Exception:
-            pass
+        with start_span(
+            "vgrag.milvus.collection_stats",
+            {
+                "db.system": "milvus",
+                "vgrag.collection_count": 3,
+            },
+        ):
+            try:
+                if self.client.has_collection(self.entity_collection):
+                    entity_stats = self.client.get_collection_stats(self.entity_collection)
+                    stats["entity_count"] = entity_stats.get("row_count", 0)
+            except Exception:
+                pass
 
-        try:
-            if self.client.has_collection(self.relation_collection):
-                relation_stats = self.client.get_collection_stats(self.relation_collection)
-                stats["relation_count"] = relation_stats.get("row_count", 0)
-        except Exception:
-            pass
+            try:
+                if self.client.has_collection(self.relation_collection):
+                    relation_stats = self.client.get_collection_stats(self.relation_collection)
+                    stats["relation_count"] = relation_stats.get("row_count", 0)
+            except Exception:
+                pass
 
-        try:
-            if self.client.has_collection(self.passage_collection):
-                passage_stats = self.client.get_collection_stats(self.passage_collection)
-                stats["passage_count"] = passage_stats.get("row_count", 0)
-        except Exception:
-            pass
+            try:
+                if self.client.has_collection(self.passage_collection):
+                    passage_stats = self.client.get_collection_stats(self.passage_collection)
+                    stats["passage_count"] = passage_stats.get("row_count", 0)
+            except Exception:
+                pass
 
         return stats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from contextlib import suppress
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,14 +12,22 @@ from vector_graph_rag.graph.graph import Graph
 from vector_graph_rag.storage.milvus import MilvusStore
 
 
+def close_milvus_store(store: MilvusStore) -> None:
+    """Close the underlying Milvus client if the installed pymilvus supports it."""
+    close = getattr(store.client, "close", None)
+    if callable(close):
+        close()
+
+
 @pytest.fixture
 def temp_milvus_uri():
     """Create a temporary Milvus database file."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
         yield f.name
     # Cleanup
-    if os.path.exists(f.name):
-        os.unlink(f.name)
+    for path in [f.name, f"{f.name}.lock"]:
+        if os.path.exists(path):
+            os.unlink(path)
 
 
 @pytest.fixture
@@ -54,7 +63,9 @@ def milvus_store(mock_settings, mock_embedding_model):
     )
     store.create_collections(drop_existing=True)
     yield store
-    store.drop_collections()
+    with suppress(Exception):
+        store.drop_collections()
+    close_milvus_store(store)
 
 
 @pytest.fixture
@@ -66,4 +77,6 @@ def graph(mock_settings, mock_embedding_model):
     )
     g.create_collections(drop_existing=True)
     yield g
-    g.drop_collections()
+    with suppress(Exception):
+        g.drop_collections()
+    close_milvus_store(g._store)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,14 +2,39 @@
 
 import os
 import tempfile
+from contextlib import suppress
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from tests.conftest import close_milvus_store
 from vector_graph_rag.api.app import create_app
 from vector_graph_rag.config import Settings
 from vector_graph_rag.graph.graph import Graph
+
+
+def _attach_span_exporter(exporter: InMemorySpanExporter) -> None:
+    """Attach a test exporter to the active OpenTelemetry provider."""
+    processor = SimpleSpanProcessor(exporter)
+    provider = trace.get_tracer_provider()
+    if hasattr(provider, "add_span_processor"):
+        provider.add_span_processor(processor)
+        return
+
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    try:
+        trace.set_tracer_provider(provider)
+    except Exception:
+        current_provider = trace.get_tracer_provider()
+        if not hasattr(current_provider, "add_span_processor"):
+            raise
+        current_provider.add_span_processor(processor)
 
 
 @pytest.fixture
@@ -27,8 +52,9 @@ def test_settings():
         collection_prefix="api_test",
     )
 
-    if os.path.exists(temp_uri):
-        os.unlink(temp_uri)
+    for path in [temp_uri, f"{temp_uri}.lock"]:
+        if os.path.exists(path):
+            os.unlink(path)
 
 
 @pytest.fixture
@@ -51,13 +77,26 @@ def app(test_settings, mock_embedding_model):
     graph.create_collections(drop_existing=True)
     application.state.graph_instances["default"] = graph
 
-    return application
+    yield application
+
+    with suppress(Exception):
+        graph.drop_collections()
+    close_milvus_store(graph._store)
 
 
 @pytest.fixture
 def client(app):
     """Create test client."""
     return TestClient(app)
+
+
+@pytest.fixture
+def span_exporter():
+    """Create an in-memory span exporter for API middleware assertions."""
+    exporter = InMemorySpanExporter()
+    _attach_span_exporter(exporter)
+    yield exporter
+    exporter.clear()
 
 
 class TestHealthEndpoint:
@@ -71,6 +110,35 @@ class TestHealthEndpoint:
         data = response.json()
         assert data["status"] == "ok"
         assert "version" in data
+
+
+class TestObservabilityMiddleware:
+    """Tests for API request tracing."""
+
+    def test_request_context_headers_are_added_to_span(self, client, span_exporter):
+        """Test request headers and graph context are attached to API spans."""
+        response = client.get(
+            "/health?graph_name=finance",
+            headers={
+                "x-request-id": "req-api",
+                "x-tenant-id": "tenant-api",
+            },
+        )
+
+        assert response.status_code == 200
+
+        spans = [
+            span for span in span_exporter.get_finished_spans() if span.name == "vgrag.api.request"
+        ]
+        assert spans
+        span = spans[-1]
+        assert span.attributes["vgrag.request_id"] == "req-api"
+        assert span.attributes["vgrag.tenant_id"] == "tenant-api"
+        assert span.attributes["vgrag.graph_name"] == "finance"
+        assert span.attributes["http.request.method"] == "GET"
+        assert span.attributes["http.response.status_code"] == 200
+        assert span.attributes["vgrag.has_request_id"] is True
+        assert span.attributes["vgrag.has_tenant_id"] is True
 
 
 class TestListGraphsEndpoint:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,254 @@
+import os
+import tempfile
+from contextlib import suppress
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from langchain_core.documents import Document
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from vector_graph_rag.config import Settings
+from vector_graph_rag.observability import (
+    get_observability_attributes,
+    observability_context,
+    start_span,
+)
+from vector_graph_rag.rag import VectorGraphRAG
+
+_SPAN_EXPORTER = InMemorySpanExporter()
+
+
+def _attach_span_exporter(exporter: InMemorySpanExporter) -> None:
+    processor = SimpleSpanProcessor(exporter)
+    provider = trace.get_tracer_provider()
+    if hasattr(provider, "add_span_processor"):
+        provider.add_span_processor(processor)
+        return
+
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    try:
+        trace.set_tracer_provider(provider)
+    except Exception:
+        current_provider = trace.get_tracer_provider()
+        if not hasattr(current_provider, "add_span_processor"):
+            raise
+        current_provider.add_span_processor(processor)
+
+
+_attach_span_exporter(_SPAN_EXPORTER)
+
+
+@pytest.fixture(autouse=True)
+def clear_finished_spans():
+    _SPAN_EXPORTER.clear()
+    yield
+    _SPAN_EXPORTER.clear()
+
+
+def _finished_spans():
+    return list(_SPAN_EXPORTER.get_finished_spans())
+
+
+def _span_by_name(name: str):
+    for span in _finished_spans():
+        if span.name == name:
+            return span
+    raise AssertionError(f"Span not found: {name}")
+
+
+class FakeEmbeddingBackend:
+    dimension = 8
+
+    def encode(self, texts, text_type="query"):
+        del text_type
+        if isinstance(texts, str):
+            texts = [texts]
+        return np.array([[0.1] * self.dimension for _ in texts])
+
+
+def _fake_chat_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=content))]
+    return response
+
+
+def _create_test_rag(collection_prefix: str) -> tuple[VectorGraphRAG, str]:
+    temp_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    temp_file.close()
+    os.unlink(temp_file.name)
+    settings = Settings(
+        openai_api_key="test-key",
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+        embedding_dimension=8,
+        milvus_uri=temp_file.name,
+        collection_prefix=collection_prefix,
+        use_llm_cache=False,
+    )
+    with patch(
+        "vector_graph_rag.storage.embeddings.get_provider",
+        return_value=FakeEmbeddingBackend(),
+    ):
+        rag = VectorGraphRAG(settings=settings)
+    rag._answer_generator.client.chat.completions.create = MagicMock(
+        return_value=_fake_chat_response("Alpha owns Beta.")
+    )
+    return rag, temp_file.name
+
+
+def _remove_temp_milvus_file(milvus_uri: str) -> None:
+    for path in [milvus_uri, f"{milvus_uri}.lock"]:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def _cleanup_test_rag(rag: VectorGraphRAG, milvus_uri: str) -> None:
+    with suppress(Exception):
+        rag._store.drop_collections()
+    close = getattr(rag._store.client, "close", None)
+    if callable(close):
+        close()
+    _remove_temp_milvus_file(milvus_uri)
+
+
+def test_observability_context_sets_attributes_on_spans():
+    with observability_context(
+        request_id="req-123",
+        tenant_id="tenant-a",
+        graph_name="finance",
+        source="file-123",
+        attributes={"workspace_id": "workspace-a", "ignored": None},
+    ):
+        with start_span("vgrag.test", {"vgrag.record_count": 2, "unsafe": {"a": 1}}):
+            pass
+
+    span = _span_by_name("vgrag.test")
+    assert span.attributes["vgrag.request_id"] == "req-123"
+    assert span.attributes["vgrag.tenant_id"] == "tenant-a"
+    assert span.attributes["vgrag.graph_name"] == "finance"
+    assert span.attributes["vgrag.source"] == "file-123"
+    assert span.attributes["workspace_id"] == "workspace-a"
+    assert "ignored" not in span.attributes
+    assert span.attributes["vgrag.record_count"] == 2
+    assert span.attributes["unsafe"] == "{'a': 1}"
+    assert get_observability_attributes() == {}
+
+
+def test_observability_helpers_are_noops_when_opentelemetry_is_unavailable(monkeypatch):
+    import vector_graph_rag.observability as observability
+
+    monkeypatch.setattr(observability, "trace", None)
+
+    with observability.observability_context(request_id="req-noop"):
+        assert observability.get_observability_attributes()["vgrag.request_id"] == "req-noop"
+        with observability.start_span("vgrag.noop", {"vgrag.record_count": 1}) as span:
+            assert span is None
+
+    assert observability.get_observability_attributes() == {}
+
+
+def test_rag_incremental_upsert_emits_source_context_and_milvus_spans():
+    rag, milvus_uri = _create_test_rag("otel_incremental_upsert")
+    try:
+        documents = [
+            Document(
+                page_content="Alpha owns Beta.",
+                id="chunk-1",
+                metadata={
+                    "source": "file-alpha",
+                    "triplets": [["Alpha", "owns", "Beta"]],
+                },
+            )
+        ]
+
+        with observability_context(request_id="req-upsert", tenant_id="tenant-a"):
+            result = rag.upsert_documents_by_source(
+                documents,
+                source="file-alpha",
+                extract_triplets=False,
+                show_progress=False,
+            )
+
+        assert len(result.documents) == 1
+
+        span_names = {span.name for span in _finished_spans()}
+        assert "vgrag.upsert_documents_by_source" in span_names
+        assert "vgrag.delete_documents_by_source" in span_names
+        assert "vgrag.graph.build" in span_names
+        assert "vgrag.graph.insert_incremental" in span_names
+        assert "vgrag.embedding.batch" in span_names
+        assert "vgrag.milvus.insert" in span_names
+        assert "vgrag.milvus.query" in span_names
+
+        operation_span = _span_by_name("vgrag.upsert_documents_by_source")
+        assert operation_span.attributes["vgrag.request_id"] == "req-upsert"
+        assert operation_span.attributes["vgrag.tenant_id"] == "tenant-a"
+        assert operation_span.attributes["vgrag.source"] == "file-alpha"
+        assert operation_span.attributes["vgrag.document_count"] == 1
+        assert operation_span.attributes["vgrag.extract_triplets"] is False
+
+        nested_milvus_span = _span_by_name("vgrag.milvus.insert")
+        assert nested_milvus_span.attributes["vgrag.request_id"] == "req-upsert"
+        assert nested_milvus_span.attributes["vgrag.tenant_id"] == "tenant-a"
+        assert nested_milvus_span.attributes["db.system"] == "milvus"
+    finally:
+        _cleanup_test_rag(rag, milvus_uri)
+
+
+def test_rag_query_emits_trace_without_query_text_or_answer():
+    rag, milvus_uri = _create_test_rag("otel_query")
+    try:
+        rag.upsert_documents_by_source(
+            [
+                Document(
+                    page_content="Alpha owns Beta.",
+                    id="chunk-1",
+                    metadata={
+                        "source": "file-alpha",
+                        "triplets": [["Alpha", "owns", "Beta"]],
+                    },
+                )
+            ],
+            source="file-alpha",
+            extract_triplets=False,
+            show_progress=False,
+        )
+        retriever = rag._ensure_retriever()
+        retriever.entity_extractor.extract = MagicMock(return_value=["alpha"])
+        _SPAN_EXPORTER.clear()
+
+        with observability_context(request_id="req-query", tenant_id="tenant-a"):
+            result = rag.query(
+                "What does Alpha own?",
+                use_reranking=False,
+                filter='source == "file-alpha"',
+            )
+
+        assert result.answer == "Alpha owns Beta."
+
+        span_names = {span.name for span in _finished_spans()}
+        assert "vgrag.query" in span_names
+        assert "vgrag.retrieve.graph" in span_names
+        assert "vgrag.retrieve.entities" in span_names
+        assert "vgrag.retrieve.relations" in span_names
+        assert "vgrag.subgraph.expand" in span_names
+        assert "vgrag.retrieve.passages_from_relations" in span_names
+        assert "vgrag.answer" in span_names
+
+        query_span = _span_by_name("vgrag.query")
+        assert query_span.attributes["vgrag.request_id"] == "req-query"
+        assert query_span.attributes["vgrag.tenant_id"] == "tenant-a"
+        assert query_span.attributes["vgrag.has_filter"] is True
+        assert query_span.attributes["vgrag.question_length"] == len("What does Alpha own?")
+
+        for span in _finished_spans():
+            attribute_values = [str(value) for value in span.attributes.values()]
+            assert "What does Alpha own?" not in attribute_values
+            assert "Alpha owns Beta." not in attribute_values
+    finally:
+        _cleanup_test_rag(rag, milvus_uri)

--- a/uv.lock
+++ b/uv.lock
@@ -3044,6 +3044,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
@@ -5953,6 +5967,8 @@ all = [
     { name = "ollama" },
     { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -5971,6 +5987,7 @@ api = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 dev = [
+    { name = "opentelemetry-sdk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -6018,6 +6035,9 @@ mineru = [
 mistral = [
     { name = "mistralai" },
 ]
+observability = [
+    { name = "opentelemetry-api" },
+]
 ollama = [
     { name = "ollama" },
 ]
@@ -6059,6 +6079,8 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version == '3.10.*' and extra == 'onnx'", specifier = ">=1.17,<1.24" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.17" },
     { name = "openai", specifier = ">=1.0.0" },
+    { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pymilvus", specifier = ">=2.4.0,<2.6.10" },
@@ -6086,10 +6108,10 @@ requires-dist = [
     { name = "trafilatura", marker = "extra == 'mineru'", specifier = ">=2.0.0" },
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.30.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.27.0" },
-    { name = "vector-graph-rag", extras = ["dev", "api", "hf", "google", "voyage", "jina", "mistral", "ollama", "local", "onnx"], marker = "extra == 'all'" },
+    { name = "vector-graph-rag", extras = ["dev", "api", "hf", "google", "voyage", "jina", "mistral", "ollama", "local", "onnx", "observability"], marker = "extra == 'all'" },
     { name = "voyageai", marker = "extra == 'voyage'", specifier = ">=0.3" },
 ]
-provides-extras = ["dev", "api", "hf", "google", "voyage", "jina", "mistral", "ollama", "local", "onnx", "all", "loaders", "docling", "mineru", "docs"]
+provides-extras = ["dev", "api", "hf", "google", "voyage", "jina", "mistral", "ollama", "local", "onnx", "observability", "all", "loaders", "docling", "mineru", "docs"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "trafilatura", specifier = ">=2.0.0" }]


### PR DESCRIPTION
## Summary
- Add optional OpenTelemetry helpers for request context and custom spans
- Instrument ingestion, loaders, embeddings, Milvus storage, retrieval, reranking, answer generation, and API requests
- Document observability setup, span coverage, and data-safety behavior
- Improve Milvus Lite test cleanup for repeated test runs

## Tests
- uv run pytest -q
- uv run pytest tests/test_observability.py tests/test_api.py -q
- uv run pytest tests/test_graph.py -q
- uv run ruff check src tests/conftest.py tests/test_observability.py tests/test_api.py
- uv run mkdocs build --strict
- uv lock --check
- git diff --check